### PR TITLE
Auto-convert TimeTypes to/from arrow time types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ julia:
   - 1.0
   - 1
   - nightly
+branches:
+  only:
+  - master
+  - gh-pages # For building documentation
+  - /^testing-.*$/ # testing branches
+  - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 matrix:
   allow_failures:
     - julia: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,14 @@ matrix:
   exclude:
     - os: osx
       arch: x86
-  include:
-    - stage: "Documentation"
-      julia: 1
-      os: linux
-      script:
-        - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build("Arrow")'
-        - julia --project=docs/ docs/make.jl
-      after_success: skip
+  # include:
+  #   - stage: "Documentation"
+  #     julia: 1
+  #     os: linux
+  #     script:
+  #       - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build("Arrow")'
+  #       - julia --project=docs/ docs/make.jl
+  #     after_success: skip
 notifications:
   email: false
 after_success:

--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -1,6 +1,7 @@
 module Arrow
 
 using Mmap
+import Dates
 using Tables, SentinelArrays
 
 using Base: @propagate_inbounds

--- a/src/FlatBuffers/FlatBuffers.jl
+++ b/src/FlatBuffers/FlatBuffers.jl
@@ -105,7 +105,9 @@ macro scopedenum(T, syms...)
                 $(Base.Enums.membershiptest(:x, values)) || enum_argument_error($(Expr(:quote, typename)), x)
                 return Core.bitcast($(esc(typename)), convert($(basetype), x))
             end
-            Base.Enums.namemap(::Type{$(esc(typename))}) = $(esc(namemap))
+            if isdefined(Base.Enums, :namemap)
+                Base.Enums.namemap(::Type{$(esc(typename))}) = $(esc(namemap))
+            end
             Base.getproperty(::Type{$(esc(typename))}, sym::Symbol) = sym in $syms ? getfield($(esc(mod)), sym) : getfield($(esc(typename)), sym)
             Base.typemin(x::Type{$(esc(typename))}) = $(esc(typename))($lo)
             Base.typemax(x::Type{$(esc(typename))}) = $(esc(typename))($hi)

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -21,6 +21,7 @@ function default end
 default(T) = zero(T)
 
 finaljuliatype(T) = T
+finaljuliatype(::Type{Missing}) = Missing
 finaljuliatype(::Type{Union{T, Missing}}) where {T} = Union{Missing, finaljuliatype(T)}
 
 function juliaeltype(f::Meta.Field)

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -20,6 +20,9 @@ function default end
 
 default(T) = zero(T)
 
+finaljuliatype(T) = T
+finaljuliatype(::Type{Union{T, Missing}}) where {T} = Union{Missing, finaljuliatype(T)}
+
 function juliaeltype(f::Meta.Field)
     T = juliaeltype(f, f.type)
     return f.nullable ? Union{T, Missing} : T
@@ -150,7 +153,10 @@ function arrowtype(b, ::Type{Decimal{P, S}}) where {P, S}
     return Meta.Decimal, Meta.decimalEnd(b), nothing
 end
 
-struct Date{U, T}
+abstract type ArrowTimeType end
+Base.write(io::IO, x::ArrowTimeType) = Base.write(io, x.x)
+
+struct Date{U, T} <: ArrowTimeType
     x::T
 end
 
@@ -160,9 +166,11 @@ bitwidth(x::Meta.DateUnit) = x == Meta.DateUnit.DAY ? Int32 : Int64
 Date{Meta.DateUnit.DAY}(days) = Date{Meta.DateUnit.DAY, Int32}(Int32(days))
 Date{Meta.DateUnit.MILLISECOND}(ms) = Date{Meta.DateUnit.MILLISECOND, Int64}(Int64(ms))
 
-function juliaeltype(f::Meta.Field, x::Meta.Date)
-    return Date{x.unit, bitwidth(x.unit)}
-end
+juliaeltype(f::Meta.Field, x::Meta.Date) = Date{x.unit, bitwidth(x.unit)}
+finaljuliatype(::Type{Date{Meta.DateUnit.DAY, Int32}}) = Dates.Date
+Base.convert(::Type{Dates.Date}, x::Date{Meta.DateUnit.DAY, Int32}) = Dates.Date(Dates.UTD(Int64(x.x + UNIX_EPOCH_DATE)))
+finaljuliatype(::Type{Date{Meta.DateUnit.MILLISECOND, Int64}}) = Dates.DateTime
+Base.convert(::Type{Dates.DateTime}, x::Date{Meta.DateUnit.MILLISECOND, Int64}) = Dates.DateTime(Dates.UTM(Int64(x.x + UNIX_EPOCH_DATETIME)))
 
 function arrowtype(b, ::Type{Date{U, T}}) where {U, T}
     Meta.dateStart(b)
@@ -170,7 +178,15 @@ function arrowtype(b, ::Type{Date{U, T}}) where {U, T}
     return Meta.Date, Meta.dateEnd(b), nothing
 end
 
-struct Time{U, T}
+arrowtype(b, ::Type{Dates.Date}) = arrowtype(b, Date{Meta.DateUnit.DAY, Int32})
+const UNIX_EPOCH_DATE = Dates.value(Dates.Date(1970))
+Base.convert(::Type{Date{Meta.DateUnit.DAY, Int32}}, x::Dates.Date) = Date{Meta.DateUnit.DAY, Int32}(Int32(Dates.value(x) - UNIX_EPOCH_DATE))
+
+arrowtype(b, ::Type{Dates.DateTime}) = arrowtype(b, Date{Meta.DateUnit.MILLISECOND, Int64})
+const UNIX_EPOCH_DATETIME = Dates.value(Dates.DateTime(1970))
+Base.convert(::Type{Date{Meta.DateUnit.MILLISECOND, Int64}}, x::Dates.DateTime) = Date{Meta.DateUnit.MILLISECOND, Int64}(Int64(Dates.value(x) - UNIX_EPOCH_DATETIME))
+
+struct Time{U, T} <: ArrowTimeType
     x::T
 end
 
@@ -179,9 +195,12 @@ Base.zero(::Type{Time{U, T}}) where {U, T} = Time{U, T}(T(0))
 bitwidth(x::Meta.TimeUnit) = x == Meta.TimeUnit.SECOND || x == Meta.TimeUnit.MILLISECOND ? Int32 : Int64
 Time{U}(x) where {U <: Meta.TimeUnit} = Time{U, bitwidth(U)}(bitwidth(U)(x))
 
-function juliaeltype(f::Meta.Field, x::Meta.Time)
-    return Time{x.unit, bitwidth(x.unit)}
-end
+juliaeltype(f::Meta.Field, x::Meta.Time) = Time{x.unit, bitwidth(x.unit)}
+finaljuliatype(::Type{<:Time}) = Dates.Time
+periodtype(U::Meta.TimeUnit) = U === Meta.TimeUnit.SECOND ? Dates.Second :
+                               U === Meta.TimeUnit.MILLISECOND ? Dates.Millisecond :
+                               U === Meta.TimeUnit.MICROSECOND ? Dates.Microsecond : Dates.Nanosecond
+Base.convert(::Type{Dates.Time}, x::Time{U, T}) where {U, T} = Dates.Time(Dates.Nanosecond(Dates.tons(periodtype(U)(x.x))))
 
 function arrowtype(b, ::Type{Time{U, T}}) where {U, T}
     Meta.timeStart(b)
@@ -189,7 +208,10 @@ function arrowtype(b, ::Type{Time{U, T}}) where {U, T}
     return Meta.Time, Meta.timeEnd(b), nothing
 end
 
-struct Timestamp{U, TZ}
+arrowtype(b, ::Type{Dates.Time}) = arrowtype(b, Time{Meta.TimeUnit.NANOSECOND, Int64})
+Base.convert(::Type{Time{Meta.TimeUnit.NANOSECOND, Int64}}, x::Dates.Time) = Time{Meta.TimeUnit.NANOSECOND, Int64}(Dates.value(x))
+
+struct Timestamp{U, TZ} <: ArrowTimeType
     x::Int64
 end
 
@@ -199,6 +221,10 @@ function juliaeltype(f::Meta.Field, x::Meta.Timestamp)
     return Timestamp{x.unit, x.timezone === nothing ? nothing : Symbol(x.timezone)}
 end
 
+finaljuliatype(::Type{Timestamp{U, nothing}}) where {U} = Dates.DateTime
+Base.convert(::Type{Dates.DateTime}, x::Timestamp{U, nothing}) where {U} =
+    Dates.DateTime(Dates.UTM(Int64(Dates.toms(periodtype(U)(x.x)) + UNIX_EPOCH_DATETIME)))
+
 function arrowtype(b, ::Type{Timestamp{U, TZ}}) where {U, TZ}
     tz = TZ !== nothing ? FlatBuffers.createstring!(b, String(TZ)) : FlatBuffers.UOffsetT(0)
     Meta.timestampStart(b)
@@ -207,7 +233,7 @@ function arrowtype(b, ::Type{Timestamp{U, TZ}}) where {U, TZ}
     return Meta.Timestamp, Meta.timestampEnd(b), nothing
 end
 
-struct Interval{U, T}
+struct Interval{U, T} <: ArrowTimeType
     x::T
 end
 
@@ -227,7 +253,7 @@ function arrowtype(b, ::Type{Interval{U, T}}) where {U, T}
     return Meta.Interval, Meta.intervalEnd(b), nothing
 end
 
-struct Duration{U}
+struct Duration{U} <: ArrowTimeType
     x::Int64
 end
 
@@ -237,11 +263,22 @@ function juliaeltype(f::Meta.Field, x::Meta.Duration)
     return Duration{x.unit}
 end
 
+finaljuliatype(::Type{Duration{U}}) where {U} = periodtype(U)
+Base.convert(::Type{P}, x::Duration{U}) where {P <: Dates.Period, U} = P(periodtype(U)(x.x))
+
 function arrowtype(b, ::Type{Duration{U}}) where {U}
     Meta.durationStart(b)
     Meta.durationAddUnit(b, U)
     return Meta.Duration, Meta.durationEnd(b), nothing
 end
+
+arrowperiodtype(P) = Meta.TimeUnit.SECOND
+arrowperiodtype(::Type{Dates.Millisecond}) = Meta.TimeUnit.MILLISECOND
+arrowperiodtype(::Type{Dates.Microsecond}) = Meta.TimeUnit.MICROSECOND
+arrowperiodtype(::Type{Dates.Nanosecond}) = Meta.TimeUnit.NANOSECOND
+
+arrowtype(b, ::Type{P}) where {P <: Dates.Period} = arrowtype(b, Duration{arrowperiodtype(P)})
+Base.convert(::Type{Duration{U}}, x::Dates.Period) where {U} = Duration{U}(Dates.value(periodtype(U)(x)))
 
 # nested types; call juliaeltype recursively on nested children
 function juliaeltype(f::Meta.Field, list::Union{Meta.List, Meta.LargeList})

--- a/src/table.jl
+++ b/src/table.jl
@@ -116,7 +116,6 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
     for (i, (k, T, col)) in enumerate(zip(names(t), types(t), columns(t)))
         if convert
             TT = finaljuliatype(T)
-            @show T, TT
             if TT !== T
                 types(t)[i] = TT
                 col = converter(TT, col)

--- a/src/table.jl
+++ b/src/table.jl
@@ -36,11 +36,11 @@ Tables.getcolumn(t::Table, i::Int) = columns(t)[i]
 Tables.getcolumn(t::Table, nm::Symbol) = lookup(t)[nm]
 
 # high-level user API functions
-Table(io::IO, pos::Integer=1, len=nothing; debug::Bool=false) = Table(Base.read(io), pos, len; debug=debug)
-Table(str::String, pos::Integer=1, len=nothing; debug::Bool=false) = Table(Mmap.mmap(str), pos, len; debug=debug)
+Table(io::IO, pos::Integer=1, len=nothing; debug::Bool=false, convert::Bool=true) = Table(Base.read(io), pos, len; debug=debug, convert=convert)
+Table(str::String, pos::Integer=1, len=nothing; debug::Bool=false, convert::Bool=true) = Table(Mmap.mmap(str), pos, len; debug=debug, convert=convert)
 
 # will detect whether we're reading a Table from a file or stream
-function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothing}=nothing; debug::Bool=false)
+function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothing}=nothing; debug::Bool=false, convert::Bool=true)
     len = something(tlen, length(bytes))
     if len > 24 &&
         _startswith(bytes, off, FILE_FORMAT_MAGIC_BYTES) &&
@@ -113,8 +113,17 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
         end
     end
     lu = lookup(t)
-    for (k, v) in zip(names(t), columns(t))
-        lu[k] = v
+    for (i, (k, T, col)) in enumerate(zip(names(t), types(t), columns(t)))
+        if convert
+            TT = finaljuliatype(T)
+            @show T, TT
+            if TT !== T
+                types(t)[i] = TT
+                col = converter(TT, col)
+                columns(t)[i] = col
+            end
+        end
+        lu[k] = col
     end
     return t
 end
@@ -131,12 +140,24 @@ struct Batch
 end
 
 function Base.iterate(x::BatchIterator{debug}, pos=x.startpos) where {debug}
-    pos + 3 > length(x.bytes) && return nothing
-    readbuffer(x.bytes, pos, UInt32) == CONTINUATION_INDICATOR_BYTES || return nothing
+    if pos + 3 > length(x.bytes)
+        debug && println("not enough bytes left for another batch message")
+        return nothing
+    end
+    if readbuffer(x.bytes, pos, UInt32) != CONTINUATION_INDICATOR_BYTES
+        debug && println("didn't find continuation byte to keep parsing messages: $(readbuffer(x.bytes, pos, UInt32))")
+        return nothing
+    end
     pos += 4
-    pos + 3 > length(x.bytes) && return nothing
+    if pos + 3 > length(x.bytes)
+        debug && println("not enough bytes left to read length of another batch message")
+        return nothing
+    end
     msglen = readbuffer(x.bytes, pos, Int32)
-    msglen == 0 && return nothing
+    if msglen == 0
+        debug && println("message has 0 length; terminating message parsing")
+        return nothing
+    end
     pos += 4
     msg = FlatBuffers.getrootas(Meta.Message, x.bytes, pos-1)
     pos += msglen
@@ -189,7 +210,6 @@ end
 
 function build(T, f::Meta.Field, L::ListTypes, batch, rb, nodeidx, bufferidx, debug)
     validity = buildbitmap(batch, rb, bufferidx, debug)
-    debug && @show validity
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
     debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
@@ -214,7 +234,6 @@ end
 
 function build(T, f::Meta.Field, L::Union{Meta.FixedSizeBinary, Meta.FixedSizeList}, batch, rb, nodeidx, bufferidx, debug)
     validity = buildbitmap(batch, rb, bufferidx, debug)
-    debug && @show validity
     bufferidx += 1
     len = rb.nodes[nodeidx].length
     nodeidx += 1
@@ -239,7 +258,6 @@ end
 
 function build(T, f::Meta.Field, L::Meta.Struct, batch, rb, nodeidx, bufferidx, debug)
     validity = buildbitmap(batch, rb, bufferidx, debug)
-    debug && @show validity
     bufferidx += 1
     len = rb.nodes[nodeidx].length
     NT = Base.nonmissingtype(T)
@@ -291,7 +309,6 @@ end
 # primitives
 function build(T, f::Meta.Field, ::L, batch, rb, nodeidx, bufferidx, debug) where {L}
     validity = buildbitmap(batch, rb, bufferidx, debug)
-    debug && @show validity
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
     debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -240,3 +240,5 @@ Base.IndexStyle(::Type{<:Converter}) = Base.IndexLinear()
 Base.size(x::Converter) = (length(x.data),)
 Base.eltype(x::Converter{T, A}) where {T, A} = T
 Base.getindex(x::Converter{T}, i::Int) where {T} = convert(T, getindex(x.data, i))
+
+maybemissing(::Type{T}) where {T} = T === Missing ? Missing : Base.nonmissingtype(T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -89,7 +89,7 @@ end
 
 # read a single element from a byte vector
 # copied from read(::IOBuffer, T) in Base
-function readbuffer(t::AbstractVector{UInt8}, pos::Int, ::Type{T}) where {T}
+function readbuffer(t::AbstractVector{UInt8}, pos::Integer, ::Type{T}) where {T}
     GC.@preserve t begin
         ptr::Ptr{T} = pointer(t, pos)
         x = unsafe_load(ptr)

--- a/src/write.jl
+++ b/src/write.jl
@@ -215,7 +215,7 @@ function fieldoffset(b, colidx, name, T, dictencodings)
         id, encodingtype, _ = dictencodings[colidx]
         _, inttype, _ = arrowtype(b, encodingtype)
         Meta.dictionaryEncodingStart(b)
-        Meta.dictionaryEncodingAddId(b, id)
+        Meta.dictionaryEncodingAddId(b, Int64(id))
         Meta.dictionaryEncodingAddIndexType(b, inttype)
         # TODO: support isOrdered?
         Meta.dictionaryEncodingAddIsOrdered(b, false)
@@ -291,7 +291,7 @@ function makerecordbatch(b, sch::Tables.Schema{names, types}, columns, dictencod
 
     # write record batch object
     Meta.recordBatchStart(b)
-    Meta.recordBatchAddLength(b, nrows)
+    Meta.recordBatchAddLength(b, Int64(nrows))
     Meta.recordBatchAddNodes(b, nodes)
     Meta.recordBatchAddBuffers(b, buffers)
     return Meta.recordBatchEnd(b), bodylen
@@ -301,7 +301,7 @@ function makedictionarybatchmsg(sch::Tables.Schema{names, types}, columns, id, i
     b = FlatBuffers.Builder(1024)
     recordbatch, bodylen = makerecordbatch(b, sch, columns, nothing, debug)
     Meta.dictionaryBatchStart(b)
-    Meta.dictionaryBatchAddId(b, id)
+    Meta.dictionaryBatchAddId(b, Int64(id))
     Meta.dictionaryBatchAddData(b, recordbatch)
     Meta.dictionaryBatchAddIsDelta(b, isdelta)
     dictionarybatch = Meta.dictionaryBatchEnd(b)

--- a/src/write.jl
+++ b/src/write.jl
@@ -25,6 +25,12 @@ function write(io::IO, tbl; debug::Bool=false)
     return write(io, tbl, false, debug)
 end
 
+if isdefined(Tables, :partitions)
+    parts = Tables.partitions
+else
+    parts = x -> (x,)
+end
+
 function write(io, source, writetofile, debug)
     if writetofile
         Base.write(io, "ARROW1\0\0")
@@ -38,7 +44,7 @@ function write(io, source, writetofile, debug)
     tsk = Threads.@spawn for msg in msgs
         Base.write(io, msg)
     end
-    @sync for (i, tbl) in enumerate(Tables.partitions(source))
+    @sync for (i, tbl) in enumerate(parts(source))
         if i == 1
             cols = Tables.columns(tbl)
             sch[] = Tables.schema(cols)

--- a/src/write.jl
+++ b/src/write.jl
@@ -413,7 +413,10 @@ function makenodesbuffers!(::Type{T}, col, fieldnodes, fieldbuffers, bufferoffse
     push!(fieldbuffers, Buffer(bufferoffset, blen))
     bufferoffset += padding(blen)
     if T <: AbstractString || T <: AbstractVector{UInt8}
-        blen = datasizeof(col)
+        blen = 0
+        for x in col
+            blen += sizeof(x)
+        end
         push!(fieldbuffers, Buffer(bufferoffset, blen))
         bufferoffset += padding(blen)
     else

--- a/src/write.jl
+++ b/src/write.jl
@@ -28,7 +28,7 @@ end
 if isdefined(Tables, :partitions)
     parts = Tables.partitions
 else
-    parts = x -> (x,)
+    parts(x) = (x,)
     parts(x::Tuple) = x
 end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -321,6 +321,15 @@ function makenodesbuffers!(::Type{T}, col, fieldnodes, fieldbuffers, bufferoffse
     return bufferoffset + padding(blen)
 end
 
+makenodesbuffers!(::Type{Dates.Date}, col, fieldnodes, fieldbuffers, bufferoffset) =
+    makenodesbuffers!(Date{Meta.DateUnit.DAY, Int32}, converter(Date{Meta.DateUnit.DAY, Int32}, col), fieldnodes, fieldbuffers, bufferoffset)
+makenodesbuffers!(::Type{Dates.Time}, col, fieldnodes, fieldbuffers, bufferoffset) =
+    makenodesbuffers!(Time{Meta.TimeUnit.NANOSECOND, Int64}, converter(Time{Meta.TimeUnit.NANOSECOND, Int64}, col), fieldnodes, fieldbuffers, bufferoffset)
+makenodesbuffers!(::Type{Dates.DateTime}, col, fieldnodes, fieldbuffers, bufferoffset) =
+    makenodesbuffers!(Date{Meta.DateUnit.MILLISECOND, Int64}, converter(Date{Meta.DateUnit.MILLISECOND, Int64}, col), fieldnodes, fieldbuffers, bufferoffset)
+makenodesbuffers!(::Type{P}, col, fieldnodes, fieldbuffers, bufferoffset) where {P <: Dates.Period} =
+    makenodesbuffers!(Duration{arrowperiodtype(P)}, converter(Duration{arrowperiodtype(P)}, col), fieldnodes, fieldbuffers, bufferoffset)
+
 function writebitmap(io, col)
     nullcount(col) == 0 && return 0
     len = _length(col)
@@ -348,6 +357,11 @@ function writebuffer(io, ::Type{T}, col) where {T}
     writezeros(io, paddinglength(n))
     return
 end
+
+writebuffer(io, ::Type{Dates.Date}, col) = writebuffer(io, Date{Meta.DateUnit.DAY, Int32}, converter(Date{Meta.DateUnit.DAY, Int32}, col))
+writebuffer(io, ::Type{Dates.Time}, col) = writebuffer(io, Time{Meta.TimeUnit.NANOSECOND, Int64}, converter(Time{Meta.TimeUnit.NANOSECOND, Int64}, col))
+writebuffer(io, ::Type{Dates.DateTime}, col) = writebuffer(io, Date{Meta.DateUnit.MILLISECOND, Int64}, converter(Date{Meta.DateUnit.MILLISECOND, Int64}, col))
+writebuffer(io, ::Type{P}, col) where {P <: Dates.Period} = writebuffer(io, Duration{arrowperiodtype(P)}, converter(Duration{arrowperiodtype(P)}, col))
 
 function makenodesbuffers!(::Type{T}, col, fieldnodes, fieldbuffers, bufferoffset) where {T <: Union{AbstractString, AbstractVector}}
     len = _length(col)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,7 +100,12 @@ tt = Arrow.Table(io; debug=true)
 @test all(isequal.(values(t), values(tt)))
 
 # multiple record batches
-t = Tables.partitioner(((col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],), (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],)))
+if isdefined(Tables, :partitioner)
+    xx = Tables.partitioner
+else
+    xx = Tuple
+end
+t = xx(((col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],), (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],)))
 io = IOBuffer()
 Arrow.write(io, t)
 seekstart(io)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,7 +56,7 @@ t = (
 io = IOBuffer()
 Arrow.write(io, t)
 seekstart(io)
-tt = Arrow.Table(io)
+tt = Arrow.Table(io; convert=false)
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
 
@@ -109,9 +109,20 @@ tt = Arrow.Table(io)
 @test isequal(tt.col1, vcat([1,2,3,4,5,6,7,8,9,missing], [1,2,3,4,5,6,7,8,9,missing]))
 @test eltype(tt.col1) === Union{Int64, Missing}
 
+# auto-converting types
+t = (
+    col1=[Date(2001, 1, 2), Date(2010, 10, 10), Date(2020, 12, 1)],
+    col2=[Time(1, 1, 2), Time(13, 10, 10), Time(22, 12, 1)],
+    col3=[DateTime(2001, 1, 2), DateTime(2010, 10, 10), DateTime(2020, 12, 1)]
+)
+io = IOBuffer()
+Arrow.write(io, t; debug=true)
+seekstart(io)
+tt = Arrow.Table(io; debug=true)
+@test length(tt) == length(t)
+@test all(isequal.(values(t), values(tt)))
+
 #TODO:
 #  -test Map
-#  -figure out auto-converting to/from julia/arrow types
-
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Arrow, Tables
+using Test, Arrow, Tables, Dates
 
 @testset "Arrow" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,8 +78,8 @@ tt = Arrow.Table(io)
 
 # unions
 t = (
-    col1=Arrow.DenseUnionVector(Union{Int64, Float64, Missing}[1, 2.0, 3, 4.0, missing]),
-    col2=Arrow.SparseUnionVector(Union{Int64, Float64, Missing}[1, 2.0, 3, 4.0, missing]),
+    col1=Arrow.DenseUnionVector([1, 2.0, 3, 4.0, missing]),
+    col2=Arrow.SparseUnionVector([1, 2.0, 3, 4.0, missing]),
 )
 io = IOBuffer()
 Arrow.write(io, t)


### PR DESCRIPTION
These are pretty cheap conversions and makes the Date, Time, Timestamp,
and Duration arrow types must more friendly to work with. I'm not sure
Interval has a real clear mapping, so it's left out for now (it also
mentions that Interval isn't even required for full arrow
compatibility). The last arrow type that doesn't currently map to a
native Julia type is Decimal. That will take a bit more digging because
the spec isn't very detailed on it's exact representation. I plan on
asking the arrow mailing list for more details and we can do that later.