### PR TITLE
Check if column implements DataAPI.refarray for dict encoding

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,9 @@ Tables = "1" # should be 1.1 for Tables.partitions
 SentinelArrays = "1"
 
 [extras]
+PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "PooledArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["quinnj <quinn.jacobd@gmail.com>", "ExpandingMan <expandingman@proton
 version = "1.0.0"
 
 [deps]
+DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
@@ -11,6 +12,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 julia = "1"
+DataAPI = "1"
 Tables = "1" # should be 1.1 for Tables.partitions
 SentinelArrays = "1"
 

--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -2,7 +2,7 @@ module Arrow
 
 using Mmap
 import Dates
-using Tables, SentinelArrays
+using DataAPI, Tables, SentinelArrays
 
 using Base: @propagate_inbounds
 import Base: ==

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -244,6 +244,10 @@ Base.eltype(x::Converter{T, A}) where {T, A} = T
 Base.getindex(x::Converter{T}, i::Int) where {T} = convert(T, getindex(x.data, i))
 Base.getindex(x::Converter{Symbol, A}, i::Int) where {T, A <: AbstractVector{String}} = Symbol(getindex(x.data, i))
 Base.getindex(x::Converter{Char, A}, i::Int) where {T, A <: AbstractVector{String}} = getindex(x.data, i)[1]
+Base.getindex(x::Converter{String, A}, i::Int) where {T, A <: AbstractVector{Symbol}} = String(getindex(x.data, i))
+Base.getindex(x::Converter{String, A}, i::Int) where {T, A <: AbstractVector{Char}} = string(getindex(x.data, i))
+DataAPI.refarray(x::Converter) = DataAPI.refarray(x.data)
+DataAPI.refpool(x::Converter{T}) where {T} = converter(T, DataAPI.refpool(x.data))
 
 maybemissing(::Type{T}) where {T} = T === Missing ? Missing : Base.nonmissingtype(T)
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -473,7 +473,7 @@ function makenodesbuffers!(colidx, types, columns, dictencodings, fieldnodes, fi
             T = eltype(refvals)
             col = (x - one(T) for x in refvals)
         else
-            _, T, vals = msg.dictencodings[colidx]
+            _, T, vals = dictencodings[colidx]
             col = DictEncoder(col, vals, T)
         end
         len = _length(col)

--- a/src/write.jl
+++ b/src/write.jl
@@ -290,7 +290,6 @@ function Base.write(io::IO, msg::Message, blocks, sch)
             # @show typeof(col), col
             if msg.dictencodings !== nothing && haskey(msg.dictencodings, i)
                 refvals = DataAPI.refarray(col.data)
-                @show typeof(refvals), typeof(col.data)
                 if refvals !== col.data
                     T = eltype(refvals)
                     col = (x - one(T) for x in refvals)
@@ -299,7 +298,6 @@ function Base.write(io::IO, msg::Message, blocks, sch)
                     col = DictEncoder(col, vals, T)
                 end
             end
-            @show col
             writebuffer(io, T === Missing ? Missing : Base.nonmissingtype(T), col)
         end
     end

--- a/src/write.jl
+++ b/src/write.jl
@@ -202,7 +202,7 @@ function toarrowtable(x)
     fieldmetadata = Dict{Int, Dict{String, String}}()
     Tables.eachcolumn(sch, cols) do col, i, nm
         dictencode = false
-        if DataAPI.refarray(col) !== col
+        if col isa AbstractArray && DataAPI.refarray(col) !== col
             dictencode = true
             types[i] = eltype(DataAPI.refpool(col))
         end

--- a/src/write.jl
+++ b/src/write.jl
@@ -64,11 +64,18 @@ end
                 if col isa DictEncode
                     id = dictid[]
                     dictid[] += 1
-                    values = unique(col)
-                    dictencodings[i] = (id, encodingtype(length(values)), values)
+                    refpool = DataAPI.refpool(col.data)
+                    if refpool !== nothing
+                        values = refpool
+                        IT = eltype(DataAPI.refarray(col.data))
+                    else
+                        values = unique(col)
+                        IT = encodingtype(length(values))
+                    end
+                    dictencodings[i] = (id, IT, values)
                 end
             end
-            @show sch[]
+            debug && @show sch[]
             put!(msgs, makeschemamsg(sch[], cols, dictencodings))
             if !isempty(dictencodings)
                 for (colidx, (id, T, values)) in dictencodings
@@ -86,8 +93,14 @@ end
                         for (colidx, (id, T, values)) in dictencodings
                             dictsch = Tables.Schema((:col,), (eltype(values),))
                             col = Tables.getcolumn(cols, colidx)
+                            refpool = DataAPI.refpool(col.data)
+                            if refpool !== nothing
+                                newvals = refpool
+                            else
+                                newvals = col
+                            end
                             # get new values we haven't seen before for delta update
-                            vals = setdiff(col, values)
+                            vals = setdiff(newvals, values)
                             put!(msgs, makedictionarybatchmsg(dictsch, (col=vals,), id, true, debug))
                             # add new values to existing set for future diffs
                             union!(values, vals)
@@ -107,8 +120,14 @@ else
                         for (colidx, (id, T, values)) in dictencodings
                             dictsch = Tables.Schema((:col,), (eltype(values),))
                             col = Tables.getcolumn(cols, colidx)
+                            refpool = DataAPI.refpool(col.data)
+                            if refpool !== nothing
+                                newvals = refpool
+                            else
+                                newvals = col
+                            end
                             # get new values we haven't seen before for delta update
-                            vals = setdiff(col, values)
+                            vals = setdiff(newvals, values)
                             put!(msgs, makedictionarybatchmsg(dictsch, (col=vals,), id, true, debug))
                             # add new values to existing set for future diffs
                             union!(values, vals)
@@ -176,15 +195,20 @@ end
 function toarrowtable(x)
     cols = Tables.columns(x)
     sch = Tables.schema(cols)
-    types = sch.types
+    types = collect(sch.types)
     N = length(types)
     newcols = Vector{Any}(undef, N)
     newtypes = Vector{Type}(undef, N)
     fieldmetadata = Dict{Int, Dict{String, String}}()
     Tables.eachcolumn(sch, cols) do col, i, nm
+        dictencode = false
+        if DataAPI.refarray(col) !== col
+            dictencode = true
+            types[i] = eltype(DataAPI.refpool(col))
+        end
         T, newcol = toarrow(types[i], i, col, fieldmetadata)
-        @inbounds newtypes[i] = T
-        @inbounds newcols[i] = newcol
+        newtypes[i] = T
+        newcols[i] = dictencode ? DictEncode(newcol) : newcol
     end
     return ToArrowTable(Tables.Schema(sch.names, newtypes), newcols, fieldmetadata)
 end
@@ -199,14 +223,14 @@ function toarrow(::Type{Symbol}, i, col, fm)
     meta = get!(() -> Dict{String, String}(), fm, i)
     meta["ARROW:extension:name"] = "JuliaLang.Symbol"
     meta["ARROW:extension:metadata"] = ""
-    return String, (String(x) for x in col)
+    return String, converter(String, col)
 end
 
 function toarrow(::Type{Char}, i, col, fm)
     meta = get!(() -> Dict{String, String}(), fm, i)
     meta["ARROW:extension:name"] = "JuliaLang.Char"
     meta["ARROW:extension:metadata"] = ""
-    return String, (string(x) for x in col)
+    return String, converter(String, col)
 end
 
 Tables.columns(x::ToArrowTable) = x
@@ -263,10 +287,19 @@ function Base.write(io::IO, msg::Message, blocks, sch)
         for i = 1:length(Tables.columnnames(msg.columns))
             col = Tables.getcolumn(msg.columns, i)
             T = types[i]
+            # @show typeof(col), col
             if msg.dictencodings !== nothing && haskey(msg.dictencodings, i)
-                _, T, vals = msg.dictencodings[i]
-                col = DictEncoder(col, vals, T)
+                refvals = DataAPI.refarray(col.data)
+                @show typeof(refvals), typeof(col.data)
+                if refvals !== col.data
+                    T = eltype(refvals)
+                    col = (x - one(T) for x in refvals)
+                else
+                    _, T, vals = msg.dictencodings[i]
+                    col = DictEncoder(col, vals, T)
+                end
             end
+            @show col
             writebuffer(io, T === Missing ? Missing : Base.nonmissingtype(T), col)
         end
     end
@@ -437,8 +470,14 @@ function makenodesbuffers!(colidx, types, columns, dictencodings, fieldnodes, fi
     T = fieldtype(types, colidx)
     col = Tables.getcolumn(columns, colidx)
     if dictencodings !== nothing && haskey(dictencodings, colidx)
-        _, T, vals = dictencodings[colidx]
-        col = DictEncoder(col, vals, T)
+        refvals = DataAPI.refarray(col.data)
+        if refvals !== col.data
+            T = eltype(refvals)
+            col = (x - one(T) for x in refvals)
+        else
+            _, T, vals = msg.dictencodings[colidx]
+            col = DictEncoder(col, vals, T)
+        end
         len = _length(col)
         nc = nullcount(col)
         push!(fieldnodes, FieldNode(len, nc))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, Arrow, Tables, Dates
+using Test, Arrow, Tables, Dates, PooledArrays
 
 struct MapTable
     x
@@ -99,7 +99,28 @@ tt = Arrow.Table(io)
 
 # dict encodings
 t = (
+    col1=Arrow.DictEncode([4, 5, 6]),
+)
+io = IOBuffer()
+Arrow.write(io, t; debug=true)
+seekstart(io)
+tt = Arrow.Table(io; debug=true)
+@test length(tt) == length(t)
+@test all(isequal.(values(t), values(tt)))
+
+t = (
     col1=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
+)
+io = IOBuffer()
+Arrow.write(io, t; debug=true)
+seekstart(io)
+tt = Arrow.Table(io; debug=true)
+@test length(tt) == length(t)
+@test all(isequal.(values(t), values(tt)))
+
+# PooledArrays
+t = (
+    col1=PooledArray([4,5,6,6]),
 )
 io = IOBuffer()
 Arrow.write(io, t; debug=true)


### PR DESCRIPTION
Fixes #2. The `DataAPI.refarray` and `DataAPI.refpool` are meant to
allow custom array types to signal that they internally store integer
ref indices along with a value pool. This is a great integration with
the arrow format, which has a specific "dict encoded" format that
follows this same format (integer indices w/ value pool). So here we
leverage that by checking if an incoming column implements the interface
and, if so, signal that it should be dict encoded in the arrow format.