### PR TITLE
Support custom metadata for schema and columns

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -145,6 +145,10 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
         end
         lu[k] = col
     end
+    meta = sch.custom_metadata
+    if meta !== nothing
+        setmetadata!(t, Dict(String(kv.key) => String(kv.value) for kv in meta))
+    end
     return t
 end
 
@@ -211,6 +215,10 @@ function Base.iterate(x::VectorIterator{debug}, (columnidx, nodeidx, bufferidx)=
     else
         debug && println("parsing column=$columnidx, T=$(x.types[columnidx]), len=$(x.batch.msg.header.nodes[nodeidx].length)")
         A, nodeidx, bufferidx = build(x.types[columnidx], field, x.batch, x.batch.msg.header, nodeidx, bufferidx, debug)
+    end
+    meta = field.custom_metadata
+    if meta !== nothing
+        setmetadata!(A, Dict(String(kv.key) => String(kv.value) for kv in meta))
     end
     return A, (columnidx + 1, nodeidx, bufferidx)
 end

--- a/test/arrowjson.jl
+++ b/test/arrowjson.jl
@@ -557,7 +557,6 @@ function Base.isequal(df::DataFile, tbl::Arrow.Table)
     i = 1
     for (col1, col2) in zip(Tables.Columns(df), Tables.Columns(tbl))
         if isequal(col1, col2)
-            @show i
             return false
         end
         i += 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -204,5 +204,19 @@ tt = Arrow.Table(io)
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
 
+t = (col1=Int64[1,2,3,4,5,6,7,8,9,10],)
+meta = Dict("key1" => "value1", "key2" => "value2")
+Arrow.setmetadata!(t, meta)
+meta2 = Dict("colkey1" => "colvalue1", "colkey2" => "colvalue2")
+Arrow.setmetadata!(t.col1, meta2)
+io = IOBuffer()
+Arrow.write(io, t)
+seekstart(io)
+tt = Arrow.Table(io)
+@test length(tt) == length(t)
+@test tt.col1 == t.col1
+@test eltype(tt.col1) === Int64
+@test Arrow.getmetadata(tt) == meta
+@test Arrow.getmetadata(tt.col1) == meta2
 
 end


### PR DESCRIPTION
Closes #13. This PR adds two new functions: `Arrow.getmetadata(x)` and
`Arrow.setmetadata!(x, ::Dict{String, String})`, which allows, rather
obviously, setting metadata for an arbitrary object and then retrieving
that metadata. By utilizing these functions, users can get/set custom
metadata that is serialized in the arrow format at the schema level and
field (column) level. More specifically, to set arrow schema custom
metadata, a user would call `Arrow.setmetadata!(tbl, meta)` on their
table object `tbl`. To retrive arrow schema custom metadata, one can
call `tbl = Arrow.Table(...); meta = Arrow.getmetadata(tbl)`. Similarly
for column/field-level metadata, one can call `Arrow.setmetadata!(col,
colmeta)` to cause custom metadata to be serialized in the arrow
message, and call `Arrow.getmetadata(tbl.colX)` to retrive custom
metadata for a specific column in an `Arrow.Table`.

Note that technically the arrow `Message` and `Footer` objects also
allow setting custom metadata, but those are not addressed at all in
this PR since they seem to be less useful/urgent.