### PR TITLE
Big refactoring to simplify code and implement more parts of the spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ matrix:
   exclude:
     - os: osx
       arch: x86
+    - os: linux
+      arch: x86
+      julia: 1.0
   # include:
   #   - stage: "Documentation"
   #     julia: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - windows
 arch:
   - x64
-  - x86
+  # - x86
 julia:
   - 1.0
   - 1

--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,10 @@ SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-julia = "1"
+julia = "1.3"
 DataAPI = "1"
 PooledArrays = "0.5"
-Tables = "1" # should be 1.1 for Tables.partitions
+Tables = "1.1"
 SentinelArrays = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["quinnj <quinn.jacobd@gmail.com>", "ExpandingMan <expandingman@proton
 version = "1.0.0"
 
 [deps]
+CodecLz4 = "5ba52731-8f18-5e0d-9241-30f10d1ec561"
+CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
 DataAPI = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"

--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -2,7 +2,7 @@ module Arrow
 
 using Mmap
 import Dates
-using DataAPI, Tables, SentinelArrays, PooledArrays
+using DataAPI, Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd
 
 using Base: @propagate_inbounds
 import Base: ==
@@ -18,9 +18,11 @@ using .FlatBuffers
 include("metadata/Flatbuf.jl")
 using .Flatbuf; const Meta = Flatbuf
 
+include("arrowtypes.jl")
+using .ArrowTypes
 include("utils.jl")
-include("eltypes.jl")
 include("arraytypes.jl")
+include("eltypes.jl")
 include("table.jl")
 include("write.jl")
 

--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -7,6 +7,31 @@ using DataAPI, Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd
 using Base: @propagate_inbounds
 import Base: ==
 
+const DEBUG_LEVEL = Ref(0)
+
+function setdebug!(level::Int)
+    DEBUG_LEVEL[] = level
+    return
+end
+
+function withdebug(f, level)
+    lvl = DEBUG_LEVEL[]
+    try
+        setdebug!(level)
+        f()
+    finally
+        setdebug!(lvl)
+    end
+end
+
+macro debug(level, msg)
+    esc(quote
+        if DEBUG_LEVEL[] >= $level
+            println(string("DEBUG: ", $(QuoteNode(__source__.file)), ":", $(QuoteNode(__source__.line)), " ", $msg))
+        end
+    end)
+end
+
 const ALIGNMENT = 8
 const FILE_FORMAT_MAGIC_BYTES = b"ARROW1"
 const CONTINUATION_INDICATOR_BYTES = 0xffffffff

--- a/src/FlatBuffers/FlatBuffers.jl
+++ b/src/FlatBuffers/FlatBuffers.jl
@@ -23,7 +23,12 @@ include("builder.jl")
 include("table.jl")
 
 function Base.show(io::IO, x::TableOrStruct)
-    show(io, NamedTuple{propertynames(x)}(Tuple(getproperty(x, y) for y in propertynames(x))))
+    print(io, "$(typeof(x))")
+    if isempty(propertynames(x))
+        print(io, "()")
+    else
+        show(io, NamedTuple{propertynames(x)}(Tuple(getproperty(x, y) for y in propertynames(x))))
+    end
 end
 
 abstract type ScopedEnum{T<:Integer} <: Enum{T} end

--- a/src/arraytypes.jl
+++ b/src/arraytypes.jl
@@ -156,7 +156,7 @@ struct Primitive{T, S, A} <: ArrowVector{T}
     arrow::Vector{UInt8} # need to hold a reference to arrow memory blob
     validity::ValidityBitmap
     data::A
-    ℓ::Int
+    ℓ::Int64
     metadata::Union{Nothing, Dict{String, String}}
 end
 

--- a/src/arraytypes.jl
+++ b/src/arraytypes.jl
@@ -612,8 +612,13 @@ isdictencoded(d::DictEncoded) = true
 isdictencoded(x) = false
 isdictencoded(c::Compressed{Z, A}) where {Z, A <: DictEncoded} = true
 
+signedtype(::Type{UInt8}) = Int8
+signedtype(::Type{UInt16}) = Int16
+signedtype(::Type{UInt32}) = Int32
+signedtype(::Type{UInt64}) = Int64
+
 indtype(d::D) where {D <: DictEncoded} = indtype(D)
-indtype(::Type{DictEncoded{T, S, A}}) where {T, S, A} = signed(S)
+indtype(::Type{DictEncoded{T, S, A}}) where {T, S, A} = signedtype(S)
 indtype(c::Compressed{Z, A}) where {Z, A <: DictEncoded} = indtype(A)
 
 getid(d::DictEncoded) = d.encoding.id

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -7,6 +7,12 @@ abstract type ArrowType end
 ArrowType(x::T) where {T} = ArrowType(T)
 ArrowType(::Type{T}) where {T} = isprimitivetype(T) ? PrimitiveType() : StructType()
 
+function arrowconvert end
+
+arrowconvert(T, x) = convert(T, x)
+arrowconvert(::Type{Union{T, Missing}}, x) where {T} = arrowconvert(T, x)
+arrowconvert(::Type{Union{T, Missing}}, ::Missing) where {T} = missing
+
 struct NullType <: ArrowType end
 
 ArrowType(::Type{Missing}) = NullType()
@@ -19,12 +25,23 @@ ArrowType(::Type{Bool}) = PrimitiveType()
 
 struct ListType <: ArrowType end
 
+isstringtype(T) = false
+isstringtype(::Type{Union{T, Missing}}) where {T} = isstringtype(T)
+
 ArrowType(::Type{<:AbstractString}) = ListType()
+isstringtype(::Type{<:AbstractString}) = true
+
+ArrowType(::Type{Symbol}) = ListType()
+isstringtype(::Type{Symbol}) = true
+arrowconvert(::Type{Symbol}, x::String) = Symbol(x)
+arrowconvert(::Type{String}, x::Symbol) = String(x)
+
 ArrowType(::Type{<:AbstractArray}) = ListType()
 
 struct FixedSizeListType <: ArrowType end
 
 ArrowType(::Type{<:NTuple}) = FixedSizeListType()
+getsize(::Type{NTuple{N, T}}) where {N, T} = N
 
 struct MapType <: ArrowType end
 
@@ -34,10 +51,77 @@ struct StructType <: ArrowType end
 
 ArrowType(::Type{<:NamedTuple}) = StructType()
 
+@enum STRUCT_TYPES NAMEDTUPLE STRUCT # KEYWORDARGS
+
+structtype(::Type{NamedTuple{N, T}}) where {N, T} = NAMEDTUPLE
+structtype(::Type{T}) where {T} = STRUCT
+
 struct UnionType <: ArrowType end
 
 ArrowType(::Union) = UnionType()
 
 struct DictEncodedType <: ArrowType end
+
+"""
+There are a couple places when writing arrow buffers where
+we need to write a "dummy" value; it doesn't really matter
+what we write, but we need to write something of a specific
+type. So each supported writing type needs to define `default`.
+"""
+function default end
+
+default(T) = zero(T)
+default(::Type{Symbol}) = Symbol()
+default(::Type{Char}) = '\0'
+default(::Type{String}) = ""
+
+function default(::Type{A}) where {A <: AbstractVector{T}} where {T}
+    a = similar(A, 1)
+    a[1] = default(T)
+    return a
+end
+
+default(::Type{NTuple{N, T}}) where {N, T} = ntuple(i -> default(T), N)
+default(::Type{T}) where {T <: Tuple} = Tuple(default(fieldtype(T, i)) for i = 1:fieldcount(T))
+default(::Type{Dict{K, V}}) where {K, V} = Dict{K, V}()
+default(::Type{NamedTuple{names, types}}) where {names, types} = NamedTuple{names}(Tuple(default(fieldtype(types, i)) for i = 1:length(names)))
+
+const JULIA_TO_ARROW_TYPE_MAPPING = Dict{Type, Tuple{String, Type}}(
+    Char => ("JuliaLang.Char", UInt32),
+    Symbol => ("JuliaLang.Symbol", String),
+)
+
+istyperegistered(::Type{T}) where {T} = haskey(JULIA_TO_ARROW_TYPE_MAPPING, T)
+
+function getarrowtype!(meta, ::Type{T}) where {T}
+    arrowname, arrowtype = JULIA_TO_ARROW_TYPE_MAPPING[T]
+    meta["ARROW:extension:name"] = arrowname
+    meta["ARROW:extension:metadata"] = ""
+    return arrowtype
+end
+
+const ARROW_TO_JULIA_TYPE_MAPPING = Dict{String, Tuple{Type, Type}}(
+    "JuliaLang.Char" => (Char, UInt32),
+    "JuliaLang.Symbol" => (Symbol, String),
+)
+
+function extensiontype(meta)
+    if haskey(meta, "ARROW:extension:name")
+        typename = meta["ARROW:extension:name"]
+        if haskey(ARROW_TO_JULIA_TYPE_MAPPING, typename)
+            return ARROW_TO_JULIA_TYPE_MAPPING[typename][1]
+        else
+            @warn "unsupported ARROW:extension:name type: \"$typename\""
+        end
+    end
+    return nothing
+end
+
+function registertype!(juliatype::Type, arrowtype::Type, arrowname::String=string("JuliaLang.", string(juliatype)))
+    # TODO: validate that juliatype isn't already default arrow type
+    JULIA_TO_ARROW_TYPE_MAPPING[juliatype] = (arrowname, arrowtype)
+    ARROW_TO_JULIA_TYPE_MAPPING[arrowname] = (juliatype, arrowtype)
+    return
+end
 
 end # module ArrowTypes

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -1,0 +1,43 @@
+module ArrowTypes
+
+export ArrowType, NullType, PrimitiveType, ListType, FixedSizeListType, MapType, StructType, UnionType, DictEncodedType
+
+abstract type ArrowType end
+
+ArrowType(x::T) where {T} = ArrowType(T)
+ArrowType(::Type{T}) where {T} = isprimitivetype(T) ? PrimitiveType() : StructType()
+
+struct NullType <: ArrowType end
+
+ArrowType(::Type{Missing}) = NullType()
+
+struct PrimitiveType <: ArrowType end
+
+ArrowType(::Type{<:Integer}) = PrimitiveType()
+ArrowType(::Type{<:AbstractFloat}) = PrimitiveType()
+ArrowType(::Type{Bool}) = PrimitiveType()
+
+struct ListType <: ArrowType end
+
+ArrowType(::Type{<:AbstractString}) = ListType()
+ArrowType(::Type{<:AbstractArray}) = ListType()
+
+struct FixedSizeListType <: ArrowType end
+
+ArrowType(::Type{<:NTuple}) = FixedSizeListType()
+
+struct MapType <: ArrowType end
+
+ArrowType(::Type{<:Dict}) = MapType()
+
+struct StructType <: ArrowType end
+
+ArrowType(::Type{<:NamedTuple}) = StructType()
+
+struct UnionType <: ArrowType end
+
+ArrowType(::Union) = UnionType()
+
+struct DictEncodedType <: ArrowType end
+
+end # module ArrowTypes

--- a/src/metadata/Message.jl
+++ b/src/metadata/Message.jl
@@ -38,17 +38,18 @@ function Base.getproperty(x::BodyCompression, field::Symbol)
     if field === :codec
         o = FlatBuffers.offset(x, 4)
         o != 0 && return FlatBuffers.get(x, o + FlatBuffers.pos(x), CompressionType)
+        return CompressionType.LZ4_FRAME
     elseif field === :method
         o = FlatBuffers.offset(x, 6)
         o != 0 && return FlatBuffers.get(x, o + FlatBuffers.pos(x), BodyCompressionMethod)
+        return BodyCompressionMethod.BUFFER
     end
     return nothing
 end
 
 bodyCompressionStart(b::FlatBuffers.Builder) = FlatBuffers.startobject!(b, 2)
 bodyCompressionAddCodec(b::FlatBuffers.Builder, codec::CompressionType) = FlatBuffers.prependslot!(b, 0, codec, 0)
-#TODO: update offset
-bodyCompressionAddMethod(b::FlatBuffers.Builder, method::BodyCompressionMethod) = FlatBuffers.prependslot!(b, 0, method, 0)
+bodyCompressionAddMethod(b::FlatBuffers.Builder, method::BodyCompressionMethod) = FlatBuffers.prependslot!(b, 1, method, 0)
 bodyCompressionEnd(b::FlatBuffers.Builder) = FlatBuffers.endobject!(b)
 
 struct RecordBatch <: FlatBuffers.Table
@@ -82,12 +83,13 @@ function Base.getproperty(x::RecordBatch, field::Symbol)
     return nothing
 end
 
-recordBatchStart(b::FlatBuffers.Builder) = FlatBuffers.startobject!(b, 3)
+recordBatchStart(b::FlatBuffers.Builder) = FlatBuffers.startobject!(b, 4)
 recordBatchAddLength(b::FlatBuffers.Builder, length::Int64) = FlatBuffers.prependslot!(b, 0, length, 0)
 recordBatchAddNodes(b::FlatBuffers.Builder, nodes::FlatBuffers.UOffsetT) = FlatBuffers.prependoffsetslot!(b, 1, nodes, 0)
 recordBatchStartNodesVector(b::FlatBuffers.Builder, numelems) = FlatBuffers.startvector!(b, 16, numelems, 8)
 recordBatchAddBuffers(b::FlatBuffers.Builder, buffers::FlatBuffers.UOffsetT) = FlatBuffers.prependoffsetslot!(b, 2, buffers, 0)
 recordBatchStartBuffersVector(b::FlatBuffers.Builder, numelems) = FlatBuffers.startvector!(b, 16, numelems, 8)
+recordBatchAddCompression(b::FlatBuffers.Builder, c::FlatBuffers.UOffsetT) = FlatBuffers.prependoffsetslot!(b, 3, c, 0)
 recordBatchEnd(b::FlatBuffers.Builder) = FlatBuffers.endobject!(b)
 
 struct DictionaryBatch <: FlatBuffers.Table

--- a/src/metadata/Schema.jl
+++ b/src/metadata/Schema.jl
@@ -86,7 +86,7 @@ struct Union <: FlatBuffers.Table
     pos::Base.Int
 end
 
-Base.propertynames(x::Union) = (:mode, typeIds)
+Base.propertynames(x::Union) = (:mode, :typeIds)
 
 function Base.getproperty(x::Union, field::Symbol)
     if field === :mode

--- a/src/metadata/Schema.jl
+++ b/src/metadata/Schema.jl
@@ -476,7 +476,7 @@ struct Field <: FlatBuffers.Table
     pos::Base.Int
 end
 
-Base.propertynames(x::Field) = (:name, :type, :dictionary, :children, :custom_metadata)
+Base.propertynames(x::Field) = (:name, :nullable, :type, :dictionary, :children, :custom_metadata)
 
 function Base.getproperty(x::Field, field::Symbol)
     if field === :name

--- a/src/table.jl
+++ b/src/table.jl
@@ -76,14 +76,14 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
             if haskey(dictencodings, id) && header.isDelta
                 # delta
                 field = dictencoded[id]
-                values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert)
+                values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, Int64(1), Int64(1), convert)
                 dictencoding = dictencodings[id]
                 append!(dictencoding.data, values)
                 continue
             end
             # new dictencoding or replace
             field = dictencoded[id]
-            values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert)
+            values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, Int64(1), Int64(1), convert)
             A = ChainedVector([values])
             dictencodings[id] = DictEncoding{eltype(A), typeof(A)}(id, A, field.dictionary.isOrdered)
             @debug 1 "parsed dictionary batch message: id=$id, data=$values\n"
@@ -185,7 +185,7 @@ buildmetadata(f::Meta.Field) = buildmetadata(f.custom_metadata)
 buildmetadata(meta) = Dict(String(kv.key) => String(kv.value) for kv in meta)
 buildmetadata(::Nothing) = nothing
 
-function Base.iterate(x::VectorIterator, (columnidx, nodeidx, bufferidx)=(1, 1, 1))
+function Base.iterate(x::VectorIterator, (columnidx, nodeidx, bufferidx)=(Int64(1), Int64(1), Int64(1)))
     columnidx > length(x.schema.fields) && return nothing
     field = x.schema.fields[columnidx]
     @debug 2 "building top-level column: field = $(field), columnidx = $columnidx, nodeidx = $nodeidx, bufferidx = $bufferidx"

--- a/src/table.jl
+++ b/src/table.jl
@@ -38,11 +38,11 @@ Tables.getcolumn(t::Table, i::Int) = columns(t)[i]
 Tables.getcolumn(t::Table, nm::Symbol) = lookup(t)[nm]
 
 # high-level user API functions
-Table(io::IO, pos::Integer=1, len=nothing; debug::Bool=false, convert::Bool=true) = Table(Base.read(io), pos, len; debug=debug, convert=convert)
-Table(str::String, pos::Integer=1, len=nothing; debug::Bool=false, convert::Bool=true) = Table(Mmap.mmap(str), pos, len; debug=debug, convert=convert)
+Table(io::IO, pos::Integer=1, len=nothing; convert::Bool=true) = Table(Base.read(io), pos, len; convert=convert)
+Table(str::String, pos::Integer=1, len=nothing; convert::Bool=true) = Table(Mmap.mmap(str), pos, len; convert=convert)
 
 # will detect whether we're reading a Table from a file or stream
-function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothing}=nothing; debug::Bool=false, convert::Bool=true)
+function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothing}=nothing; convert::Bool=true)
     len = something(tlen, length(bytes))
     if len > 24 &&
         _startswith(bytes, off, FILE_FORMAT_MAGIC_BYTES) &&
@@ -54,59 +54,59 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
     dictencodings = Dict{Int64, DictEncoding}() # dictionary id => DictEncoding
     dictencoded = Dict{Int64, Meta.Field}() # dictionary id => field
     fieldmetadata = Dict{Int, Dict{String, String}}()
-    for batch in BatchIterator{debug}(bytes, off)
+    for batch in BatchIterator(bytes, off)
         # store custom_metadata of batch.msg?
         header = batch.msg.header
         if header isa Meta.Schema
-            debug && println("parsing schema message")
+            @debug 1 "parsing schema message"
             # assert endianness?
             # store custom_metadata?
             for (i, field) in enumerate(header.fields)
                 push!(names(t), Symbol(field.name))
                 # recursively find any dictionaries for any fields
                 getdictionaries!(dictencoded, field)
-                debug && println("parsed column from schema: name=$(names(t)[end])")
+                @debug 1 "parsed column from schema: field = $field"
             end
             sch = header
             schema(t)[] = sch
         elseif header isa Meta.DictionaryBatch
-            debug && println("parsing dictionary batch message")
             id = header.id
             recordbatch = header.data
+            @debug 1 "parsing dictionary batch message: id = $id, compression = $(recordbatch.compression)"
             if haskey(dictencodings, id) && header.isDelta
                 # delta
                 field = dictencoded[id]
-                values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert, debug)
+                values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert)
                 dictencoding = dictencodings[id]
                 append!(dictencoding.data, values)
                 continue
             end
             # new dictencoding or replace
             field = dictencoded[id]
-            values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert, debug)
+            values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert)
             A = ChainedVector([values])
             dictencodings[id] = DictEncoding{eltype(A), typeof(A)}(id, A, field.dictionary.isOrdered)
-            debug && println("parsed dictionary batch message: id=$id, data=$values\n")
+            @debug 1 "parsed dictionary batch message: id=$id, data=$values\n"
         elseif header isa Meta.RecordBatch
-            debug && println("parsing record batch message")
+            @debug 1 "parsing record batch message: compression = $(header.compression)"
             if isempty(columns(t))
                 # first RecordBatch
-                for vec in VectorIterator{debug}(sch, batch, dictencodings)
+                for vec in VectorIterator(sch, batch, dictencodings, convert)
                     push!(columns(t), vec)
                 end
-                debug && println("parsed 1st record batch")
+                @debug 1 "parsed 1st record batch"
             elseif !(columns(t)[1] isa ChainedVector)
                 # second RecordBatch
-                for (i, vec) in enumerate(VectorIterator{debug}(sch, batch, dictencodings))
+                for (i, vec) in enumerate(VectorIterator(sch, batch, dictencodings, convert))
                     columns(t)[i] = ChainedVector([columns(t)[i], vec])
                 end
-                debug && println("parsed 2nd record batch")
+                @debug 1 "parsed 2nd record batch"
             else
                 # 2+ RecordBatch
-                for (i, vec) in enumerate(VectorIterator{debug}(sch, batch, dictencodings))
+                for (i, vec) in enumerate(VectorIterator(sch, batch, dictencodings, convert))
                     append!(columns(t)[i], vec)
                 end
-                debug && println("parsed additional record batch")
+                @debug 1 "parsed additional record batch"
             end
         else
             throw(ArgumentError("unsupported arrow message type: $(typeof(header))"))
@@ -136,7 +136,7 @@ function getdictionaries!(dictencoded, field)
     return
 end
 
-struct BatchIterator{debug}
+struct BatchIterator
     bytes::Vector{UInt8}
     startpos::Int
 end
@@ -147,77 +147,77 @@ struct Batch
     pos::Int
 end
 
-function Base.iterate(x::BatchIterator{debug}, pos=x.startpos) where {debug}
+function Base.iterate(x::BatchIterator, pos=x.startpos)
     if pos + 3 > length(x.bytes)
-        debug && println("not enough bytes left for another batch message")
+        @debug 1 "not enough bytes left for another batch message"
         return nothing
     end
     if readbuffer(x.bytes, pos, UInt32) != CONTINUATION_INDICATOR_BYTES
-        debug && println("didn't find continuation byte to keep parsing messages: $(readbuffer(x.bytes, pos, UInt32))")
+        @debug 1 "didn't find continuation byte to keep parsing messages: $(readbuffer(x.bytes, pos, UInt32))"
         return nothing
     end
     pos += 4
     if pos + 3 > length(x.bytes)
-        debug && println("not enough bytes left to read length of another batch message")
+        @debug 1 "not enough bytes left to read length of another batch message"
         return nothing
     end
     msglen = readbuffer(x.bytes, pos, Int32)
     if msglen == 0
-        debug && println("message has 0 length; terminating message parsing")
+        @debug 1 "message has 0 length; terminating message parsing"
         return nothing
-    else
-        debug && println("parsing message with msglen = $msglen")
     end
     pos += 4
     msg = FlatBuffers.getrootas(Meta.Message, x.bytes, pos-1)
     pos += msglen
     # pos now points to message body
-    debug && @show msg.version, msg.bodyLength
+    @debug 1 "parsing message: msglen = $msglen, version = $(msg.version), bodyLength = $(msg.bodyLength)"
     return Batch(msg, x.bytes, pos), pos + msg.bodyLength
 end
 
-struct VectorIterator{debug}
+struct VectorIterator
     schema::Meta.Schema
     batch::Batch # batch.msg.header MUST BE RecordBatch
     dictencodings::Dict{Int64, DictEncoding}
+    convert::Bool
 end
 
+buildmetadata(f::Meta.Field) = buildmetadata(f.custom_metadata)
 buildmetadata(meta) = Dict(String(kv.key) => String(kv.value) for kv in meta)
 buildmetadata(::Nothing) = nothing
 
-function Base.iterate(x::VectorIterator{debug}, (columnidx, nodeidx, bufferidx)=(1, 1, 1)) where {debug}
+function Base.iterate(x::VectorIterator, (columnidx, nodeidx, bufferidx)=(1, 1, 1))
     columnidx > length(x.schema.fields) && return nothing
     field = x.schema.fields[columnidx]
-    debug && println("parsing column=$columnidx, T=$(field.type), len=$(x.batch.msg.header.nodes[nodeidx].length)")
-    A, nodeidx, bufferidx = build(field, x.batch, x.batch.msg.header, x.dictencodings, nodeidx, bufferidx, convert, debug)
+    @debug 2 "building top-level column: field = $(field), columnidx = $columnidx, nodeidx = $nodeidx, bufferidx = $bufferidx"
+    A, nodeidx, bufferidx = build(field, x.batch, x.batch.msg.header, x.dictencodings, nodeidx, bufferidx, x.convert)
+    @debug 2 "built top-level column: A = $(typeof(A)), columnidx = $columnidx, nodeidx = $nodeidx, bufferidx = $bufferidx"
+    @debug 3 A
     return A, (columnidx + 1, nodeidx, bufferidx)
 end
 
 const ListTypes = Union{Meta.Utf8, Meta.LargeUtf8, Meta.Binary, Meta.LargeBinary, Meta.List, Meta.LargeList}
 const LargeLists = Union{Meta.LargeUtf8, Meta.LargeBinary, Meta.LargeList}
 
-function build(field::Meta.Field, batch, rb, de, nodeidx, bufferidx, convert, debug)
+function build(field::Meta.Field, batch, rb, de, nodeidx, bufferidx, convert)
     d = field.dictionary
     if d !== nothing
-        validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+        validity = buildbitmap(batch, rb, nodeidx, bufferidx)
         bufferidx += 1
         buffer = rb.buffers[bufferidx]
-        debug && @show buffer.offset, buffer.length
-        S = d.indexType === nothing ? Int32 : juliaeltype(field, d.indexType)
+        S = d.indexType === nothing ? Int32 : juliaeltype(field, d.indexType, false)
         bytes, indices = reinterp(S, batch, buffer, rb.compression)
         encoding = de[d.id]
         A = DictEncoded(bytes, validity, indices, encoding, buildmetadata(field.custom_metadata))
         nodeidx += 1
         bufferidx += 1
     else
-        A, nodeidx, bufferidx = build(field, field.type, batch, rb, de, nodeidx, bufferidx, convert, debug)
+        A, nodeidx, bufferidx = build(field, field.type, batch, rb, de, nodeidx, bufferidx, convert)
     end
     return A, nodeidx, bufferidx
 end
 
-function buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+function buildbitmap(batch, rb, nodeidx, bufferidx)
     buffer = rb.buffers[bufferidx]
-    debug && @show :validity_bitmap, buffer.offset, buffer.length
     voff = batch.pos + buffer.offset
     node = rb.nodes[nodeidx]
     if rb.compression === nothing
@@ -258,11 +258,11 @@ function reinterp(::Type{T}, batch, buf, compression) where {T}
     end
 end
 
-function build(f::Meta.Field, L::ListTypes, batch, rb, de, nodeidx, bufferidx, convert, debug)
-    validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::ListTypes, batch, rb, de, nodeidx, bufferidx, convert)
+    @debug 2 "building array: L = $L"
+    validity = buildbitmap(batch, rb, nodeidx, bufferidx)
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
-    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
     ooff = batch.pos + buffer.offset
     OT = L isa LargeLists ? Int64 : Int32
     bytes, offs = reinterp(OT, batch, buffer, rb.compression)
@@ -272,44 +272,41 @@ function build(f::Meta.Field, L::ListTypes, batch, rb, de, nodeidx, bufferidx, c
     nodeidx += 1
     if L isa Meta.Utf8 || L isa Meta.LargeUtf8 || L isa Meta.Binary || L isa Meta.LargeBinary
         buffer = rb.buffers[bufferidx]
-        debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
         bytes, A = reinterp(UInt8, batch, buffer, rb.compression)
         bufferidx += 1
     else
         bytes = UInt8[]
-        A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert, debug)
+        A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert)
     end
     meta = buildmetadata(f.custom_metadata)
-    T, TT = juliaeltype(f, meta)
-    B = List{T, OT, typeof(A)}(bytes, validity, offsets, A, len, meta)
-    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
+    T = juliaeltype(f, meta, convert)
+    return List{T, OT, typeof(A)}(bytes, validity, offsets, A, len, meta), nodeidx, bufferidx
 end
 
-function build(f::Meta.Field, L::Union{Meta.FixedSizeBinary, Meta.FixedSizeList}, batch, rb, de, nodeidx, bufferidx, convert, debug)
-    validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::Union{Meta.FixedSizeBinary, Meta.FixedSizeList}, batch, rb, de, nodeidx, bufferidx, convert)
+    @debug 2 "building array: L = $L"
+    validity = buildbitmap(batch, rb, nodeidx, bufferidx)
     bufferidx += 1
     len = rb.nodes[nodeidx].length
     nodeidx += 1
     if L isa Meta.FixedSizeBinary
         buffer = rb.buffers[bufferidx]
-        debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
         bytes, A = reinterp(UInt8, batch, buffer, rb.compression)
         bufferidx += 1
     else
         bytes = UInt8[]
-        A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert, debug)
+        A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert)
     end
     meta = buildmetadata(f.custom_metadata)
-    T, TT = juliaeltype(f, meta)
-    B = FixedSizeList{T, typeof(A)}(bytes, validity, A, len, meta)
-    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
+    T = juliaeltype(f, meta, convert)
+    return FixedSizeList{T, typeof(A)}(bytes, validity, A, len, meta), nodeidx, bufferidx
 end
 
-function build(f::Meta.Field, L::Meta.Map, batch, rb, de, nodeidx, bufferidx, convert, debug)
-    validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::Meta.Map, batch, rb, de, nodeidx, bufferidx, convert)
+    @debug 2 "building array: L = $L"
+    validity = buildbitmap(batch, rb, nodeidx, bufferidx)
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
-    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
     ooff = batch.pos + buffer.offset
     OT = Int32
     bytes, offs = reinterp(OT, batch, buffer, rb.compression)
@@ -317,73 +314,74 @@ function build(f::Meta.Field, L::Meta.Map, batch, rb, de, nodeidx, bufferidx, co
     bufferidx += 1
     len = rb.nodes[nodeidx].length
     nodeidx += 1
-    A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert, debug)
+    A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert)
     meta = buildmetadata(f.custom_metadata)
-    T, TT = juliaeltype(f, meta)
-    B = Map{T, OT, typeof(A)}(validity, offsets, A, len, meta)
-    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
+    T = juliaeltype(f, meta, convert)
+    return Map{T, OT, typeof(A)}(validity, offsets, A, len, meta), nodeidx, bufferidx
 end
 
-function build(f::Meta.Field, L::Meta.Struct, batch, rb, de, nodeidx, bufferidx, convert, debug)
-    validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::Meta.Struct, batch, rb, de, nodeidx, bufferidx, convert)
+    @debug 2 "building array: L = $L"
+    validity = buildbitmap(batch, rb, nodeidx, bufferidx)
     bufferidx += 1
     len = rb.nodes[nodeidx].length
     vecs = []
     nodeidx += 1
     for child in f.children
-        A, nodeidx, bufferidx = build(child, batch, rb, de, nodeidx, bufferidx, convert, debug)
+        A, nodeidx, bufferidx = build(child, batch, rb, de, nodeidx, bufferidx, convert)
         push!(vecs, A)
     end
     data = Tuple(vecs)
     meta = buildmetadata(f.custom_metadata)
-    T, TT = juliaeltype(f, meta)
-    B = Struct{T, typeof(data)}(validity, data, len, meta)
-    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
+    T = juliaeltype(f, meta, convert)
+    return Struct{T, typeof(data)}(validity, data, len, meta), nodeidx, bufferidx
 end
 
-function build(f::Meta.Field, L::Meta.Union, batch, rb, de, nodeidx, bufferidx, convert, debug)
+function build(f::Meta.Field, L::Meta.Union, batch, rb, de, nodeidx, bufferidx, convert)
+    @debug 2 "building array: L = $L"
     buffer = rb.buffers[bufferidx]
-    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
     bytes, typeIds = reinterp(UInt8, batch, buffer, rb.compression)
-    debug && @show typeIds
     bufferidx += 1
     if L.mode == Meta.UnionMode.Dense
         buffer = rb.buffers[bufferidx]
-        debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
         bytes2, offsets = reinterp(Int32, batch, buffer, rb.compression)
         bufferidx += 1
     end
     vecs = []
     nodeidx += 1
     for child in f.children
-        A, nodeidx, bufferidx = build(child, batch, rb, de, nodeidx, bufferidx, convert, debug)
+        A, nodeidx, bufferidx = build(child, batch, rb, de, nodeidx, bufferidx, convert)
         push!(vecs, A)
     end
     data = Tuple(vecs)
     meta = buildmetadata(f.custom_metadata)
-    T, TT = juliaeltype(f, meta)
+    T = juliaeltype(f, meta, convert)
     if L.mode == Meta.UnionMode.Dense
         B = DenseUnion{T, typeof(data)}(bytes, bytes2, typeIds, offsets, data, meta)
     else
         B = SparseUnion{T, typeof(data)}(bytes, typeIds, data, meta)
     end
-    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
+    return B, nodeidx, bufferidx
 end
 
-function build(f::Meta.Field, L::Meta.Null, batch, rb, de, nodeidx, bufferidx, convert, debug)
+function build(f::Meta.Field, L::Meta.Null, batch, rb, de, nodeidx, bufferidx, convert)
+    @debug 2 "building array: L = $L"
     return MissingVector(rb.nodes[nodeidx].length), nodeidx + 1, bufferidx
 end
 
 # primitives
-function build(f::Meta.Field, ::L, batch, rb, de, nodeidx, bufferidx, convert, debug) where {L}
-    validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, ::L, batch, rb, de, nodeidx, bufferidx, convert) where {L}
+    @debug 2 "building array: L = $L"
+    validity = buildbitmap(batch, rb, nodeidx, bufferidx)
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
-    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
     meta = buildmetadata(f.custom_metadata)
-    T, TT = juliaeltype(f, meta)
+    # get storage type (non-converted)
+    T = juliaeltype(f, nothing, false)
+    @debug 2 "storage type for primitive: T = $T"
     bytes, A = reinterp(Base.nonmissingtype(T), batch, buffer, rb.compression)
     len = rb.nodes[nodeidx].length
-    B = Primitive(T, bytes, validity, A, len, meta)
-    return (T !== TT ? converter(TT, B) : B), nodeidx + 1, bufferidx + 1
+    T = juliaeltype(f, meta, convert)
+    @debug 2 "final julia type for primitive: T = $T"
+    return Primitive(T, bytes, validity, A, len, meta), nodeidx + 1, bufferidx + 1
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -51,8 +51,8 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
     end
     t = Table()
     sch = nothing
-    dictencodings = Dict{Int64, DictEncoding}()
-    dictencoded = Dict{Int64, Tuple{Bool, Type, Meta.Field}}()
+    dictencodings = Dict{Int64, DictEncoding}() # dictionary id => DictEncoding
+    dictencoded = Dict{Int64, Meta.Field}() # dictionary id => field
     fieldmetadata = Dict{Int, Dict{String, String}}()
     for batch in BatchIterator{debug}(bytes, off)
         # store custom_metadata of batch.msg?
@@ -63,18 +63,9 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
             # store custom_metadata?
             for (i, field) in enumerate(header.fields)
                 push!(names(t), Symbol(field.name))
-                T, metadata = juliaeltype(field)
-                if metadata !== nothing
-                    fieldmetadata[i] = metadata
-                end
-                push!(types(t), T)
-                d = field.dictionary
-                isencoded = false
-                if d !== nothing
-                    dictencoded[d.id] = (d.isOrdered, types(t)[end], field)
-                    isencoded = true
-                end
-                debug && println("parsed column from schema: name=$(names(t)[end]), type=$(types(t)[end])$(isencoded ? " dictencoded" : "")")
+                # recursively find any dictionaries for any fields
+                getdictionaries!(dictencoded, field)
+                debug && println("parsed column from schema: name=$(names(t)[end])")
             end
             sch = header
             schema(t)[] = sch
@@ -84,35 +75,35 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
             recordbatch = header.data
             if haskey(dictencodings, id) && header.isDelta
                 # delta
-                isOrdered, T, field = dictencoded[id]
-                values, _, _ = build(T, field, batch, recordbatch, 1, 1, debug)
+                field = dictencoded[id]
+                values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert, debug)
                 dictencoding = dictencodings[id]
                 append!(dictencoding.data, values)
                 continue
             end
             # new dictencoding or replace
-            isOrdered, T, field = dictencoded[id]
-            values, _, _ = build(T, field, batch, recordbatch, 1, 1, debug)
+            field = dictencoded[id]
+            values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, 1, 1, convert, debug)
             A = ChainedVector([values])
-            dictencodings[id] = DictEncoding{eltype(A), typeof(A)}(id, A, isOrdered)
+            dictencodings[id] = DictEncoding{eltype(A), typeof(A)}(id, A, field.dictionary.isOrdered)
             debug && println("parsed dictionary batch message: id=$id, data=$values\n")
         elseif header isa Meta.RecordBatch
             debug && println("parsing record batch message")
             if isempty(columns(t))
                 # first RecordBatch
-                for vec in VectorIterator{debug}(types(t), sch, batch, dictencodings)
+                for vec in VectorIterator{debug}(sch, batch, dictencodings)
                     push!(columns(t), vec)
                 end
                 debug && println("parsed 1st record batch")
             elseif !(columns(t)[1] isa ChainedVector)
                 # second RecordBatch
-                for (i, vec) in enumerate(VectorIterator{debug}(types(t), sch, batch, dictencodings))
+                for (i, vec) in enumerate(VectorIterator{debug}(sch, batch, dictencodings))
                     columns(t)[i] = ChainedVector([columns(t)[i], vec])
                 end
                 debug && println("parsed 2nd record batch")
             else
                 # 2+ RecordBatch
-                for (i, vec) in enumerate(VectorIterator{debug}(types(t), sch, batch, dictencodings))
+                for (i, vec) in enumerate(VectorIterator{debug}(sch, batch, dictencodings))
                     append!(columns(t)[i], vec)
                 end
                 debug && println("parsed additional record batch")
@@ -122,35 +113,27 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
         end
     end
     lu = lookup(t)
-    for (i, (k, T, col)) in enumerate(zip(names(t), types(t), columns(t)))
-        if haskey(fieldmetadata, i) && haskey(fieldmetadata[i], "ARROW:extension:name")
-            if fieldmetadata[i]["ARROW:extension:name"] == "JuliaLang.Symbol"
-                TT = finaljuliatype(Symbol)
-                types(t)[i] = TT
-                col = converter(TT, col)
-                columns(t)[i] = col
-            elseif fieldmetadata[i]["ARROW:extension:name"] == "JuliaLang.Char"
-                TT = finaljuliatype(Char)
-                types(t)[i] = TT
-                col = converter(TT, col)
-                columns(t)[i] = col
-            end
-        end
-        if convert
-            TT = finaljuliatype(T)
-            if TT !== T
-                types(t)[i] = TT
-                col = converter(TT, col)
-                columns(t)[i] = col
-            end
-        end
-        lu[k] = col
+    ty = types(t)
+    for (nm, col) in zip(names(t), columns(t))
+        lu[nm] = col
+        push!(ty, eltype(col))
     end
     meta = sch.custom_metadata
     if meta !== nothing
         setmetadata!(t, Dict(String(kv.key) => String(kv.value) for kv in meta))
     end
     return t
+end
+
+function getdictionaries!(dictencoded, field)
+    d = field.dictionary
+    if d !== nothing
+        dictencoded[d.id] = field
+    end
+    for child in field.children
+        getdictionaries!(dictencoded, child)
+    end
+    return
 end
 
 struct BatchIterator{debug}
@@ -189,12 +172,11 @@ function Base.iterate(x::BatchIterator{debug}, pos=x.startpos) where {debug}
     msg = FlatBuffers.getrootas(Meta.Message, x.bytes, pos-1)
     pos += msglen
     # pos now points to message body
-    debug && @show msg.bodyLength
+    debug && @show msg.version, msg.bodyLength
     return Batch(msg, x.bytes, pos), pos + msg.bodyLength
 end
 
 struct VectorIterator{debug}
-    types::Vector{Type}
     schema::Meta.Schema
     batch::Batch # batch.msg.header MUST BE RecordBatch
     dictencodings::Dict{Int64, DictEncoding}
@@ -206,30 +188,32 @@ buildmetadata(::Nothing) = nothing
 function Base.iterate(x::VectorIterator{debug}, (columnidx, nodeidx, bufferidx)=(1, 1, 1)) where {debug}
     columnidx > length(x.schema.fields) && return nothing
     field = x.schema.fields[columnidx]
-    d = field.dictionary
-    if d !== nothing
-        validity = buildbitmap(x.batch, x.batch.msg.header, nodeidx, bufferidx, debug)
-        bufferidx += 1
-        buffer = x.batch.msg.header.buffers[bufferidx]
-        debug && @show columnidx, buffer.offset, buffer.length
-        S = d.indexType === nothing ? Int32 : juliaeltype(field, d.indexType)
-        bytes, indices = reinterp(S, x.batch, buffer, x.batch.msg.header.compression)
-        encoding = x.dictencodings[d.id]
-        A = DictEncoded{x.types[columnidx], eltype(indices), typeof(encoding.data)}(bytes, validity, indices, encoding, buildmetadata(field.custom_metadata))
-        nodeidx += 1
-        bufferidx += 1
-    else
-        debug && println("parsing column=$columnidx, T=$(x.types[columnidx]), len=$(x.batch.msg.header.nodes[nodeidx].length)")
-        A, nodeidx, bufferidx = build(x.types[columnidx], field, x.batch, x.batch.msg.header, nodeidx, bufferidx, debug)
-    end
+    debug && println("parsing column=$columnidx, T=$(field.type), len=$(x.batch.msg.header.nodes[nodeidx].length)")
+    A, nodeidx, bufferidx = build(field, x.batch, x.batch.msg.header, x.dictencodings, nodeidx, bufferidx, convert, debug)
     return A, (columnidx + 1, nodeidx, bufferidx)
 end
 
 const ListTypes = Union{Meta.Utf8, Meta.LargeUtf8, Meta.Binary, Meta.LargeBinary, Meta.List, Meta.LargeList}
 const LargeLists = Union{Meta.LargeUtf8, Meta.LargeBinary, Meta.LargeList}
 
-build(T, f::Meta.Field, batch, rb, nodeidx, bufferidx, debug) =
-    build(T, f, f.type, batch, rb, nodeidx, bufferidx, debug)
+function build(field::Meta.Field, batch, rb, de, nodeidx, bufferidx, convert, debug)
+    d = field.dictionary
+    if d !== nothing
+        validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
+        bufferidx += 1
+        buffer = rb.buffers[bufferidx]
+        debug && @show buffer.offset, buffer.length
+        S = d.indexType === nothing ? Int32 : juliaeltype(field, d.indexType)
+        bytes, indices = reinterp(S, batch, buffer, rb.compression)
+        encoding = de[d.id]
+        A = DictEncoded(bytes, validity, indices, encoding, buildmetadata(field.custom_metadata))
+        nodeidx += 1
+        bufferidx += 1
+    else
+        A, nodeidx, bufferidx = build(field, field.type, batch, rb, de, nodeidx, bufferidx, convert, debug)
+    end
+    return A, nodeidx, bufferidx
+end
 
 function buildbitmap(batch, rb, nodeidx, bufferidx, debug)
     buffer = rb.buffers[bufferidx]
@@ -274,11 +258,11 @@ function reinterp(::Type{T}, batch, buf, compression) where {T}
     end
 end
 
-function build(T, f::Meta.Field, L::ListTypes, batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::ListTypes, batch, rb, de, nodeidx, bufferidx, convert, debug)
     validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
-    debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
+    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
     ooff = batch.pos + buffer.offset
     OT = L isa LargeLists ? Int64 : Int32
     bytes, offs = reinterp(OT, batch, buffer, rb.compression)
@@ -288,39 +272,44 @@ function build(T, f::Meta.Field, L::ListTypes, batch, rb, nodeidx, bufferidx, de
     nodeidx += 1
     if L isa Meta.Utf8 || L isa Meta.LargeUtf8 || L isa Meta.Binary || L isa Meta.LargeBinary
         buffer = rb.buffers[bufferidx]
-        debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
+        debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
         bytes, A = reinterp(UInt8, batch, buffer, rb.compression)
         bufferidx += 1
     else
         bytes = UInt8[]
-        A, nodeidx, bufferidx = build(eltype(Base.nonmissingtype(T)), f.children[1], batch, rb, nodeidx, bufferidx, debug)
+        A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert, debug)
     end
-    return List{T, OT, typeof(A)}(bytes, validity, offsets, A, len, buildmetadata(f.custom_metadata)), nodeidx, bufferidx
+    meta = buildmetadata(f.custom_metadata)
+    T, TT = juliaeltype(f, meta)
+    B = List{T, OT, typeof(A)}(bytes, validity, offsets, A, len, meta)
+    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
 end
 
-function build(T, f::Meta.Field, L::Union{Meta.FixedSizeBinary, Meta.FixedSizeList}, batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::Union{Meta.FixedSizeBinary, Meta.FixedSizeList}, batch, rb, de, nodeidx, bufferidx, convert, debug)
     validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
     bufferidx += 1
     len = rb.nodes[nodeidx].length
     nodeidx += 1
     if L isa Meta.FixedSizeBinary
         buffer = rb.buffers[bufferidx]
-        debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
+        debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
         bytes, A = reinterp(UInt8, batch, buffer, rb.compression)
         bufferidx += 1
     else
         bytes = UInt8[]
-        A, nodeidx, bufferidx = build(eltype(Base.nonmissingtype(T)), f.children[1], batch, rb, nodeidx, bufferidx, debug)
+        A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert, debug)
     end
-    return FixedSizeList{T, typeof(A)}(bytes, validity, A, len, buildmetadata(f.custom_metadata)), nodeidx, bufferidx
+    meta = buildmetadata(f.custom_metadata)
+    T, TT = juliaeltype(f, meta)
+    B = FixedSizeList{T, typeof(A)}(bytes, validity, A, len, meta)
+    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
 end
 
-function build(S, f::Meta.Field, L::Meta.Map, batch, rb, nodeidx, bufferidx, debug)
-    T = Base.nonmissingtype(S)
+function build(f::Meta.Field, L::Meta.Map, batch, rb, de, nodeidx, bufferidx, convert, debug)
     validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
-    debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
+    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
     ooff = batch.pos + buffer.offset
     OT = Int32
     bytes, offs = reinterp(OT, batch, buffer, rb.compression)
@@ -328,65 +317,73 @@ function build(S, f::Meta.Field, L::Meta.Map, batch, rb, nodeidx, bufferidx, deb
     bufferidx += 1
     len = rb.nodes[nodeidx].length
     nodeidx += 1
-    A, nodeidx, bufferidx = build(KeyValue{keytype(T), valtype(T)}, f.children[1], batch, rb, nodeidx, bufferidx, debug)
-    return Map{S, OT, typeof(A)}(validity, offsets, A, len, buildmetadata(f.custom_metadata)), nodeidx, bufferidx
+    A, nodeidx, bufferidx = build(f.children[1], batch, rb, de, nodeidx, bufferidx, convert, debug)
+    meta = buildmetadata(f.custom_metadata)
+    T, TT = juliaeltype(f, meta)
+    B = Map{T, OT, typeof(A)}(validity, offsets, A, len, meta)
+    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
 end
 
-function build(T, f::Meta.Field, L::Meta.Struct, batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::Meta.Struct, batch, rb, de, nodeidx, bufferidx, convert, debug)
     validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
     bufferidx += 1
     len = rb.nodes[nodeidx].length
-    NT = Base.nonmissingtype(T)
-    N = fieldcount(NT)
     vecs = []
     nodeidx += 1
-    for i = 1:N
-        A, nodeidx, bufferidx = build(fieldtype(NT, i), f.children[i], batch, rb, nodeidx, bufferidx, debug)
+    for child in f.children
+        A, nodeidx, bufferidx = build(child, batch, rb, de, nodeidx, bufferidx, convert, debug)
         push!(vecs, A)
     end
     data = Tuple(vecs)
-    return Struct{T, typeof(data)}(validity, data, len, buildmetadata(f.custom_metadata)), nodeidx, bufferidx
+    meta = buildmetadata(f.custom_metadata)
+    T, TT = juliaeltype(f, meta)
+    B = Struct{T, typeof(data)}(validity, data, len, meta)
+    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
 end
 
-function build(T, f::Meta.Field, L::Meta.Union, batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::Meta.Union, batch, rb, de, nodeidx, bufferidx, convert, debug)
     buffer = rb.buffers[bufferidx]
-    debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
+    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
     bytes, typeIds = reinterp(UInt8, batch, buffer, rb.compression)
     debug && @show typeIds
     bufferidx += 1
     if L.mode == Meta.UnionMode.Dense
         buffer = rb.buffers[bufferidx]
-        debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
+        debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
         bytes2, offsets = reinterp(Int32, batch, buffer, rb.compression)
         bufferidx += 1
     end
     vecs = []
     nodeidx += 1
-    types = eltype(T)
-    for i = 1:fieldcount(types)
-        A, nodeidx, bufferidx = build(fieldtype(types, i), f.children[i], batch, rb, nodeidx, bufferidx, debug)
+    for child in f.children
+        A, nodeidx, bufferidx = build(child, batch, rb, de, nodeidx, bufferidx, convert, debug)
         push!(vecs, A)
     end
     data = Tuple(vecs)
+    meta = buildmetadata(f.custom_metadata)
+    T, TT = juliaeltype(f, meta)
     if L.mode == Meta.UnionMode.Dense
-        return DenseUnion{T, typeof(data)}(bytes, bytes2, typeIds, offsets, data, buildmetadata(f.custom_metadata)), nodeidx, bufferidx
+        B = DenseUnion{T, typeof(data)}(bytes, bytes2, typeIds, offsets, data, meta)
     else
-        return SparseUnion{T, typeof(data)}(bytes, typeIds, data, buildmetadata(f.custom_metadata)), nodeidx, bufferidx
+        B = SparseUnion{T, typeof(data)}(bytes, typeIds, data, meta)
     end
+    return (T !== TT ? converter(TT, B) : B), nodeidx, bufferidx
 end
 
-function build(T, f::Meta.Field, L::Meta.Null, batch, rb, nodeidx, bufferidx, debug)
+function build(f::Meta.Field, L::Meta.Null, batch, rb, de, nodeidx, bufferidx, convert, debug)
     return MissingVector(rb.nodes[nodeidx].length), nodeidx + 1, bufferidx
 end
 
 # primitives
-function build(T, f::Meta.Field, ::L, batch, rb, nodeidx, bufferidx, debug) where {L}
+function build(f::Meta.Field, ::L, batch, rb, de, nodeidx, bufferidx, convert, debug) where {L}
     validity = buildbitmap(batch, rb, nodeidx, bufferidx, debug)
     bufferidx += 1
     buffer = rb.buffers[bufferidx]
-    debug && @show T, nodeidx, bufferidx, buffer.offset, buffer.length
-    S = Base.nonmissingtype(T)
-    bytes, A = reinterp(S, batch, buffer, rb.compression)
+    debug && @show nodeidx, bufferidx, buffer.offset, buffer.length
+    meta = buildmetadata(f.custom_metadata)
+    T, TT = juliaeltype(f, meta)
+    bytes, A = reinterp(Base.nonmissingtype(T), batch, buffer, rb.compression)
     len = rb.nodes[nodeidx].length
-    return Primitive{T, S, typeof(A)}(bytes, validity, A, len, buildmetadata(f.custom_metadata)), nodeidx + 1, bufferidx + 1
+    B = Primitive(T, bytes, validity, A, len, meta)
+    return (T !== TT ? converter(TT, B) : B), nodeidx + 1, bufferidx + 1
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -18,6 +18,8 @@ function writezeros(io::IO, n::Integer)
 end
 
 # efficient writing of arrays
+writearray(io, col) = writearray(io, maybemissing(eltype(col)), col)
+
 function writearray(io::IO, ::Type{T}, col) where {T}
     if col isa Vector{T}
         n = Base.write(io, col)
@@ -63,11 +65,9 @@ end
 
 Determines the number of bytes used by `n` bits, optionally with padding.
 """
-function bitpackedbytes(n::Integer, pad::Bool=true)
-    a, b = divrem(n, 8)
-    ℓ = a + (b > 0)
-    pad && (ℓ += paddinglength(ℓ))
-    return ℓ
+function bitpackedbytes(n::Integer)
+    ℓ = cld(n, 8)
+    return ℓ + paddinglength(ℓ)
 end
 
 # count # of missing elements in an iterable
@@ -101,144 +101,19 @@ function readbuffer(t::AbstractVector{UInt8}, pos::Integer, ::Type{T}) where {T}
     end
 end
 
-flatten(x) = Iterators.flatten(x)
+# # argh me mateys, don't nobody else go pirating this method
+# # this here be me own booty!
+# if !applicable(iterate, missing)
+# Base.iterate(::Missing, st=1) = st === nothing ? nothing : (missing, nothing)
+# end
 
-# we need to treat missing specially w/ length of flattened array
-_length(x) = length(x)
-_length(g::Base.Generator) = _length(g.iter)
-_length(x::Iterators.Flatten) = sum(i -> i === missing ? 1 : _length(i), x)
-
-# argh me mateys, don't nobody else go pirating this method
-# this here be me own booty!
-if !applicable(iterate, missing)
-Base.iterate(::Missing, st=1) = st === nothing ? nothing : (missing, nothing)
-end
-
-ntupleT(::Type{NTuple{N, T}}) where {N, T} = T
-ntnames(::Type{NamedTuple{names, T}}) where {names, T} = names
-ntT(::Type{NamedTuple{names, T}}) where {names, T} = T
-pairK(::Type{Pair{K, V}}) where {K, V} = K
-pairV(::Type{Pair{K, V}}) where {K, V} = V
-
-# need a custom representation of Union types since arrow unions
-# are ordered, and possibly indirected via separate typeIds array
-# here, T is Meta.UnionMode.Dense or Meta.UnionMode.Sparse,
-# typeIds is a NTuple{N, Int32}, and U is a Tuple{...} of the
-# unioned types
-struct UnionT{T, typeIds, U}
-end
-
-unionmode(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = T
-typeids(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = typeIds
-Base.eltype(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = U
-
-# convenience wrappers for signaling that an array shoudld be written
-# as with dense/sparse union arrow buffers
-struct DenseUnionVector{T, U} <: AbstractVector{UnionT{Meta.UnionMode.Dense, nothing, U}}
-    itr::T
-end
-
-DenseUnionVector(x::T) where {T} = DenseUnionVector{T, Tuple{eachunion(eltype(x))...}}(x)
-Base.IndexStyle(::Type{<:DenseUnionVector}) = Base.IndexLinear()
-Base.size(x::DenseUnionVector) = (length(x.itr),)
-Base.eltype(x::DenseUnionVector{T, U}) where {T, U} = UnionT{Meta.UnionMode.Dense, nothing, U}
-Base.iterate(x::DenseUnionVector, st...) = iterate(x.itr, st...)
-Base.getindex(x::DenseUnionVector, i::Int) = getindex(x.itr, i)
-
-struct SparseUnionVector{T, U} <: AbstractVector{UnionT{Meta.UnionMode.Sparse, nothing, U}}
-    itr::T
-end
-
-SparseUnionVector(x::T) where {T} = SparseUnionVector{T, Tuple{eachunion(eltype(x))...}}(x)
-Base.IndexStyle(::Type{<:SparseUnionVector}) = Base.IndexLinear()
-Base.size(x::SparseUnionVector) = (length(x.itr),)
-Base.eltype(x::SparseUnionVector{T, U}) where {T, U} = UnionT{Meta.UnionMode.Sparse, nothing, U}
-Base.iterate(x::SparseUnionVector, st...) = iterate(x.itr, st...)
-Base.getindex(x::SparseUnionVector, i::Int) = getindex(x.itr, i)
-
-# iterate a Julia Union{...} type, producing an array of unioned types
-function eachunion(U::Union, elems=nothing)
-    if elems === nothing
-        return eachunion(U.b, Type[U.a])
-    else
-        push!(elems, U.a)
-        return eachunion(U.b, elems)
-    end
-end
-
-function eachunion(T, elems)
-    push!(elems, T)
-    return elems
-end
-
-# dense union child array producer
-# for dense union children, we split the parent array
-# into N children arrays, each with one of the unioned types
-# only the 1st child needs to include missing values
-struct Filtered{T, I}
-    itr::I
-    len::Int64
-end
-
-function filtered(::Type{T}, itr::I) where {T, I}
-    len = Int64(0)
-    for x in itr
-        len += x isa T
-    end
-    return Filtered{T, I}(itr, len)
-end
-
-Base.length(f::Filtered) = f.len
-Base.eltype(f::Filtered{T}) where {T} = T
-
-function Base.iterate(f::Filtered{T}, st=()) where {T}
-    st = iterate(f.itr, st...)
-    st === nothing && return nothing
-    x, state = st
-    while !(x isa T)
-        st = iterate(f.itr, state)
-        st === nothing && return nothing
-        x, state = st
-    end
-    return x, (state,)
-end
-
-# sparse union child array producer
-# for sparse unions, we split the parent array into
-# N children arrays, each having the same length as the parent
-# but with one child array per unioned type; each child
-# should include the elements from parent of its type
-# and other elements can be missing/default
-struct Replaced{T, I}
-    itr::I
-end
-
-replaced(::Type{T}, itr::I) where {T, I} = Replaced{T, I}(itr)
-
-Base.length(r::Replaced) = _length(r.itr)
-Base.eltype(r::Replaced{T}) where {T} = Union{T, Missing}
-
-function Base.iterate(r::Replaced{T}, st=()) where {T}
-    st = iterate(r.itr, st...)
-    st === nothing && return nothing
-    x, state = st
-    return ifelse(x isa T, x, missing), (state,)
-end
-
-# convenience wrapper to signal that an input column should be
-# dict encoded when written to the arrow format
-# note that only top-level columns are supported for dict encoding
-# currently; (i.e. no nested dict encoding)
-struct DictEncode{T, A <: AbstractVector} <: AbstractVector{T}
-    data::A
-end
-
-DictEncode(x::A) where {A} = DictEncode{eltype(A), A}(x)
-Base.IndexStyle(::Type{<:DictEncode}) = Base.IndexLinear()
-Base.size(x::DictEncode) = (length(x.data),)
-Base.eltype(x::DictEncode{T, A}) where {T, A} = T
-Base.iterate(x::DictEncode, st...) = iterate(x.data, st...)
-Base.getindex(x::DictEncode, i::Int) = getindex(x.data, i)
+getK(::Type{Pair{K, V}}) where {K, V} = K
+getV(::Type{Pair{K, V}}) where {K, V} = V
+getN(::Type{NTuple{N, T}}) where {N, T} = N
+getT(::Type{NTuple{N, T}}) where {N, T} = T
+getnames(::Type{NamedTuple{names, T}}) where {names, T} = names
+getT(::Type{NamedTuple{names, T}}) where {names, T} = T
+getN(::Type{NamedTuple{names, T}}) where {names, T} = length(names)
 
 encodingtype(n) = n < div(typemax(Int8), 2) ? Int8 : n < div(typemax(Int16), 2) ? Int16 : n < div(typemax(Int32), 2) ? Int32 : Int64
 
@@ -281,6 +156,374 @@ end
 function readmessage(filebytes, off=9)
     @assert readbuffer(filebytes, off, UInt32) === 0xFFFFFFFF
     len = readbuffer(filebytes, off + 4, Int32)
-    @show len
+
     FlatBuffers.getrootas(Meta.Message, filebytes, off + 8)
+end
+
+# an AbstractVector version of Iterators.flatten
+# code based on SentinelArrays.ChainedVector
+struct ToList{T, A, I} <: AbstractVector{T}
+    data::Vector{A} # A is AbstractVector or AbstractString
+    inds::Vector{I}
+end
+
+stringtype(T) = false
+stringtype(::Type{T}) where {T <: AbstractString} = true
+
+function ToList(input; largelists::Bool=false)
+    AT = eltype(input)
+    ST = Base.nonmissingtype(AT)
+    T = stringtype(ST) ? UInt8 : eltype(ST)
+    len = stringtype(ST) ? sizeof : length
+    data = AT[]
+    I = largelists ? Int64 : Int32
+    inds = I[0]
+    sizehint!(data, length(input))
+    sizehint!(inds, length(input))
+    totalsize = I(0)
+    for x in input
+        if x === missing
+            push!(data, missing)
+        else
+            push!(data, x)
+            totalsize += len(x)
+            if I === Int32 && totalsize > 2147483647
+                I = Int64
+                inds = convert(Vector{Int64}, inds)
+            end
+        end
+        push!(inds, totalsize)
+    end
+    return ToList{T, AT, I}(data, inds)
+end
+
+Base.IndexStyle(::Type{<:ToList}) = Base.IndexLinear()
+Base.size(x::ToList) = (length(x.inds) == 0 ? 0 : x.inds[end],)
+
+function Base.pointer(A::ToList{UInt8}, i::Integer)
+    chunk = searchsortedfirst(A.inds, i)
+    return pointer(A.data[chunk - 1])
+end
+
+@inline function index(A::ToList, i::Integer)
+    chunk = searchsortedfirst(A.inds, i)
+    return chunk - 1, i - (@inbounds A.inds[chunk - 1])
+end
+
+Base.@propagate_inbounds getchunk(data, chunk) = @inbounds data[chunk]
+Base.@propagate_inbounds getchunk(data::Vector{A}, chunk) where {A <: Union{Missing, AbstractString}} = @inbounds codeunits(data[chunk])
+
+Base.@propagate_inbounds function Base.getindex(A::ToList, i::Integer)
+    @boundscheck checkbounds(A, i)
+    chunk, ix = index(A, i)
+    @inbounds x = getchunk(A.data, chunk)[ix]
+    return x
+end
+
+Base.@propagate_inbounds function Base.setindex!(A::ToList, v, i::Integer)
+    @boundscheck checkbounds(A, i)
+    chunk, ix = index(A, i)
+    @inbounds getchunk(A.data, chunk)[ix] = v
+    return v
+end
+
+# efficient iteration
+@inline function Base.iterate(A::ToList)
+    length(A) == 0 && return nothing
+    i = 1
+    chunk = 2
+    chunk_i = 1
+    chunk_len = A.inds[chunk]
+    while i > chunk_len
+        chunk += 1
+        chunk_len = A.inds[chunk]
+    end
+    x = getchunk(A.data, chunk - 1)[1]
+    # find next valid index
+    i += 1
+    if i > chunk_len
+        while true
+            chunk += 1
+            chunk > length(A.inds) && break
+            chunk_len = A.inds[chunk]
+            i <= chunk_len && break
+        end
+    else
+        chunk_i += 1
+    end
+    return x, (i, chunk, chunk_i, chunk_len, length(A))
+end
+
+@inline function Base.iterate(A::ToList, (i, chunk, chunk_i, chunk_len, len))
+    i > len && return nothing
+    @inbounds x = getchunk(A.data, chunk - 1)[chunk_i]
+    i += 1
+    if i > chunk_len
+        chunk_i = 1
+        while true
+            chunk += 1
+            chunk > length(A.inds) && break
+            @inbounds chunk_len = A.inds[chunk]
+            i <= chunk_len && break
+        end
+    else
+        chunk_i += 1
+    end
+    return x, (i, chunk, chunk_i, chunk_len, len)
+end
+
+# 
+struct ToFixedSizeList{T, N, A} <: AbstractVector{T}
+    data::A # A is AbstractVector or AbstractString
+end
+
+function ToFixedSizeList(input)
+    NT = Base.nonmissingtype(eltype(input)) # NTuple{N, T}
+    return ToFixedSizeList{getT(NT), getN(NT), typeof(input)}(input)
+end
+
+Base.IndexStyle(::Type{<:ToFixedSizeList}) = Base.IndexLinear()
+Base.size(x::ToFixedSizeList{T, N}) where {T, N} = (N * length(x.data),)
+
+Base.@propagate_inbounds function Base.getindex(A::ToFixedSizeList{T, N}, i::Integer) where {T, N}
+    @boundscheck checkbounds(A, i)
+    a, b = fldmod1(i, N)
+    @inbounds x = A.data[a]
+    return @inbounds x === missing ? default(T) : x[b]
+end
+
+# efficient iteration
+@inline function Base.iterate(A::ToFixedSizeList{T, N}, (i, chunk, chunk_i, len)=(1, 1, 1, length(A))) where {T, N}
+    i > len && return nothing
+    @inbounds y = A.data[chunk]
+    @inbounds x = y === missing ? default(T) : y[chunk_i]
+    if chunk_i == N
+        chunk += 1
+        chunk_i = 1
+    else
+        chunk_i += 1
+    end
+    return x, (i + 1, chunk, chunk_i, len)
+end
+
+struct ToStruct{T, i, A} <: AbstractVector{T}
+    data::A # eltype is NamedTuple
+end
+
+ToStruct(x::A, j::Integer) where {A} = ToStruct{fieldtype(Base.nonmissingtype(eltype(A)), j), j, A}(x)
+
+Base.IndexStyle(::Type{<:ToStruct}) = Base.IndexLinear()
+Base.size(x::ToStruct) = (length(x.data),)
+
+Base.@propagate_inbounds function Base.getindex(A::ToStruct{T, j}, i::Integer) where {T, j}
+    @boundscheck checkbounds(A, i)
+    @inbounds x = A.data[i]
+    return @miss_or(x, @inbounds getfield(x, j))
+end
+
+# Union arrays
+# need a custom representation of Union types since arrow unions
+# are ordered, and possibly indirected via separate typeIds array
+# here, T is Meta.UnionMode.Dense or Meta.UnionMode.Sparse,
+# typeIds is a NTuple{N, Int32}, and U is a Tuple{...} of the
+# unioned types
+struct UnionT{T, typeIds, U}
+end
+
+unionmode(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = T
+typeids(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = typeIds
+Base.eltype(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = U
+
+ArrowTypes.ArrowType(::Type{<:UnionT}) = ArrowTypes.UnionType()
+
+# convenience wrappers for signaling that an array shoudld be written
+# as with dense/sparse union arrow buffers
+struct DenseUnionVector{T, U} <: AbstractVector{UnionT{Meta.UnionMode.Dense, nothing, U}}
+    itr::T
+end
+
+DenseUnionVector(x::T) where {T} = DenseUnionVector{T, Tuple{eachunion(eltype(x))...}}(x)
+Base.IndexStyle(::Type{<:DenseUnionVector}) = Base.IndexLinear()
+Base.size(x::DenseUnionVector) = (length(x.itr),)
+Base.eltype(x::DenseUnionVector{T, U}) where {T, U} = UnionT{Meta.UnionMode.Dense, nothing, U}
+Base.iterate(x::DenseUnionVector, st...) = iterate(x.itr, st...)
+Base.getindex(x::DenseUnionVector, i::Int) = getindex(x.itr, i)
+
+struct SparseUnionVector{T, U} <: AbstractVector{UnionT{Meta.UnionMode.Sparse, nothing, U}}
+    itr::T
+end
+
+SparseUnionVector(x::T) where {T} = SparseUnionVector{T, Tuple{eachunion(eltype(x))...}}(x)
+Base.IndexStyle(::Type{<:SparseUnionVector}) = Base.IndexLinear()
+Base.size(x::SparseUnionVector) = (length(x.itr),)
+Base.eltype(x::SparseUnionVector{T, U}) where {T, U} = UnionT{Meta.UnionMode.Sparse, nothing, U}
+Base.iterate(x::SparseUnionVector, st...) = iterate(x.itr, st...)
+Base.getindex(x::SparseUnionVector, i::Int) = getindex(x.itr, i)
+
+# iterate a Julia Union{...} type, producing an array of unioned types
+function eachunion(U::Union, elems=nothing)
+    if elems === nothing
+        return eachunion(U.b, Type[U.a])
+    else
+        push!(elems, U.a)
+        return eachunion(U.b, elems)
+    end
+end
+
+function eachunion(T, elems)
+    push!(elems, T)
+    return elems
+end
+
+# produce typeIds, offsets, data tuple for DenseUnion
+isatypeid(x::T, ::Type{types}) where {T, types} = isatypeid(x, fieldtype(types, 1), types, 1)
+isatypeid(x::T, ::Type{S}, ::Type{types}, i) where {T, S, types} = x isa S ? i : isatypeid(x, fieldtype(types, i + 1), types, i + 1)
+
+function todense(::Type{UnionT{T, typeIds, U}}, x) where {T, typeIds, U}
+    typeids = typeIds === nothing ? (0:(fieldcount(U) - 1)) : typeIds
+    len = length(x)
+    types = Vector{UInt8}(undef, len)
+    offsets = Vector{Int32}(undef, len)
+    data = Tuple(Vector{i == 1 ? Union{Missing, fieldtype(U, i)} : fieldtype(U, i)}(undef, 0) for i = 1:fieldcount(U))
+    for (i, y) in enumerate(x)
+        typeid = y === missing ? 0x00 : UInt8(typeids[isatypeid(y, U)])
+        @inbounds types[i] = typeid
+        @inbounds offsets[i] = length(data[typeid + 1])
+        push!(data[typeid + 1], y)
+    end
+    return types, offsets, data
+end
+
+# sparse union child array producer
+# for sparse unions, we split the parent array into
+# N children arrays, each having the same length as the parent
+# but with one child array per unioned type; each child
+# should include the elements from parent of its type
+# and other elements can be missing/default
+function sparsetypeids(::Type{UnionT{T, typeIds, U}}, x) where {T, typeIds, U}
+    typeids = typeIds === nothing ? (0:(fieldcount(U) - 1)) : typeIds
+    len = length(x)
+    types = Vector{UInt8}(undef, len)
+    for (i, y) in enumerate(x)
+        typeid = y === missing ? 0x00 : UInt8(typeids[isatypeid(y, U)])
+        @inbounds types[i] = typeid
+    end
+    return types
+end
+
+struct ToSparseUnion{T, A} <: AbstractVector{T}
+    data::A
+end
+
+ToSparseUnion(::Type{T}, data::A) where {T, A} = ToSparseUnion{T, A}(data)
+
+Base.IndexStyle(::Type{<:ToSparseUnion}) = Base.IndexLinear()
+Base.size(x::ToSparseUnion) = (length(x.data),)
+
+Base.@propagate_inbounds function Base.getindex(A::ToSparseUnion{T}, i::Integer) where {T}
+    @boundscheck checkbounds(A, i)
+    @inbounds x = A.data[i]
+    return @inbounds x isa T ? x : default(T)
+end
+
+# ToMap
+struct ToMap{T, A, I} <: AbstractVector{T}
+    data::Vector{A} # A is a Vector{KeyValue{K, V}}
+    inds::Vector{I}
+end
+
+function ToMap(input; largelists::Bool=false)
+    AT = eltype(input)
+    ST = Base.nonmissingtype(AT)
+    PT = eltype(ST)
+    K, V = getK(PT), getV(PT)
+    T = KeyValue{K, V}
+    VT = AT !== ST ? Union{Missing, Vector{T}} : Vector{T}
+    data = VT[]
+    I = largelists ? Int64 : Int32
+    inds = I[0]
+    sizehint!(data, length(input))
+    sizehint!(inds, length(input))
+    totalsize = I(0)
+    for x in input
+        if x === missing
+            push!(data, missing)
+        else
+            push!(data, [KeyValue{K, V}(k, v) for (k, v) in pairs(x)])
+            totalsize += length(x)
+            if I === Int32 && totalsize > 2147483647
+                I = Int64
+                inds = convert(Vector{Int64}, inds)
+            end
+        end
+        push!(inds, totalsize)
+    end
+    return ToMap{T, VT, I}(data, inds)
+end
+
+Base.IndexStyle(::Type{<:ToMap}) = Base.IndexLinear()
+Base.size(x::ToMap) = (length(x.inds) == 0 ? 0 : x.inds[end],)
+
+@inline function index(A::ToMap, i::Integer)
+    chunk = searchsortedfirst(A.inds, i)
+    return chunk - 1, i - (@inbounds A.inds[chunk - 1])
+end
+
+Base.@propagate_inbounds function Base.getindex(A::ToMap, i::Integer)
+    @boundscheck checkbounds(A, i)
+    chunk, ix = index(A, i)
+    @inbounds x = A.data[chunk][ix]
+    return x
+end
+
+Base.@propagate_inbounds function Base.setindex!(A::ToMap, v, i::Integer)
+    @boundscheck checkbounds(A, i)
+    chunk, ix = index(A, i)
+    @inbounds A.data[chunk][ix] = v
+    return v
+end
+
+# efficient iteration
+@inline function Base.iterate(A::ToMap)
+    length(A) == 0 && return nothing
+    i = 1
+    chunk = 1
+    chunk_i = 1
+    chunk_len = A.inds[chunk + 1]
+    while i > chunk_len
+        chunk += 1
+        @inbounds chunk_len = A.inds[chunk + 1]
+    end
+    x = A.data[chunk][1]
+    # find next valid index
+    i += 1
+    if i > chunk_len
+        while true
+            chunk += 1
+            chunk > length(A.inds) && break
+            @inbounds chunk_len = A.inds[chunk + 1]
+            i <= chunk_len && break
+        end
+    else
+        chunk_i += 1
+    end
+    return x, (i, chunk, chunk_i, chunk_len, length(A))
+end
+
+@inline function Base.iterate(A::ToMap, (i, chunk, chunk_i, chunk_len, len))
+    i > len && return nothing
+    @inbounds x = A.data[chunk][chunk_i]
+    i += 1
+    if i > chunk_len
+        chunk_i = 1
+        while true
+            chunk += 1
+            chunk > length(A.inds) && break
+            @inbounds chunk_len = A.inds[chunk + 1]
+            i <= chunk_len && break
+        end
+    else
+        chunk_i += 1
+    end
+    return x, (i, chunk, chunk_i, chunk_len, len)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -132,8 +132,6 @@ Base.getindex(x::Converter{Symbol, A}, i::Int) where {T, A <: AbstractVector{Str
 Base.getindex(x::Converter{Char, A}, i::Int) where {T, A <: AbstractVector{String}} = getindex(x.data, i)[1]
 Base.getindex(x::Converter{String, A}, i::Int) where {T, A <: AbstractVector{Symbol}} = String(getindex(x.data, i))
 Base.getindex(x::Converter{String, A}, i::Int) where {T, A <: AbstractVector{Char}} = string(getindex(x.data, i))
-DataAPI.refarray(x::Converter) = DataAPI.refarray(x.data)
-DataAPI.refpool(x::Converter{T}) where {T} = converter(T, DataAPI.refpool(x.data))
 
 maybemissing(::Type{T}) where {T} = T === Missing ? Missing : Base.nonmissingtype(T)
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -111,7 +111,7 @@ else
         Base.write(io, msg, blocks, sch)
     end
 end
-    @sync for (i, tbl) in enumerate(parts(source))
+    @sync for (i, tbl) in enumerate(Tables.partitions(source))
         @debug 1 "processing table partition i = $i"
         if i == 1
             cols = toarrowtable(tbl, largelists, compress, denseunions, dictencode, dictencodenested)

--- a/src/write.jl
+++ b/src/write.jl
@@ -36,13 +36,6 @@ function write(io::IO, tbl; largelists::Bool=false, compress::Union{Nothing, Sym
     return write(io, tbl, file, largelists, compress, denseunions, dictencode, dictencodenested)
 end
 
-if isdefined(Tables, :partitions)
-    parts = Tables.partitions
-else
-    parts(x) = (x,)
-    parts(x::Tuple) = x
-end
-
 @static if VERSION >= v"1.3"
     const Cond = Threads.Condition
 else

--- a/test/arrowjson.jl
+++ b/test/arrowjson.jl
@@ -353,9 +353,9 @@ function FieldData(nm, ::Base.Type{T}, col, dictencodings) where {T}
             push!(children, FieldData("item", eltype(S), Arrow.flatten(skipmissing(col)), dictencodings))
         elseif S <: NTuple
             if Arrow.getT(S) == UInt8
-                DATA = [ismissing(x) ? Arrow.default(S) : String(collect(x)) for x in col]
+                DATA = [ismissing(x) ? Arrow.ArrowTypes.default(S) : String(collect(x)) for x in col]
             else
-                push!(children, FieldData("item", Arrow.getT(S), Arrow.flatten(coalesce(x, Arrow.default(S)) for x in col), dictencodings))
+                push!(children, FieldData("item", Arrow.getT(S), Arrow.flatten(coalesce(x, Arrow.ArrowTypes.default(S)) for x in col), dictencodings))
             end
         elseif S <: NamedTuple
             for (nm, typ) in zip(Arrow.getnames(S), Arrow.getT(S))

--- a/test/arrowjson.jl
+++ b/test/arrowjson.jl
@@ -334,7 +334,7 @@ function FieldData(nm, ::Base.Type{T}, col, dictencodings) where {T}
     VALIDITY = OFFSET = TYPE_ID = DATA = nothing
     children = FieldData[]
     if S <: Pair
-        return FieldData(nm, Vector{Arrow.KeyValue{Arrow.pairK(S), Arrow.pairV(S)}}, (Arrow.KeyValue(k, v) for (k, v) in pairs(col)))
+        return FieldData(nm, Vector{Arrow.KeyValue{Arrow._keytype(S), Arrow._valtype(S)}}, (Arrow.KeyValue(k, v) for (k, v) in pairs(col)))
     elseif S !== Missing
         # VALIDITY
         VALIDITY = Int8[!ismissing(x) for x in col]
@@ -352,13 +352,13 @@ function FieldData(nm, ::Base.Type{T}, col, dictencodings) where {T}
             OFFSET = Offsets(OFFSET)
             push!(children, FieldData("item", eltype(S), Arrow.flatten(skipmissing(col)), dictencodings))
         elseif S <: NTuple
-            if Arrow.ntupleT(S) == UInt8
+            if Arrow.getT(S) == UInt8
                 DATA = [ismissing(x) ? Arrow.default(S) : String(collect(x)) for x in col]
             else
-                push!(children, FieldData("item", Arrow.ntupleT(S), Arrow.flatten(coalesce(x, Arrow.default(S)) for x in col), dictencodings))
+                push!(children, FieldData("item", Arrow.getT(S), Arrow.flatten(coalesce(x, Arrow.default(S)) for x in col), dictencodings))
             end
         elseif S <: NamedTuple
-            for (nm, typ) in zip(Arrow.ntnames(S), Arrow.ntT(S))
+            for (nm, typ) in zip(Arrow.getnames(S), Arrow.getT(S))
                 push!(children, FieldData(String(nm), typ, (getfield(x, nm) for x in col), dictencodings))
             end
         elseif S <: Arrow.UnionT
@@ -480,18 +480,18 @@ function Base.getindex(x::ArrowArray{T}, i::Base.Int) where {T}
         A = ArrowArray{eltype(S)}(x.field.children[1], x.fielddata.children[1], x.dictionaries)
         return A[(offs[i] + 1):offs[i + 1]]
     elseif S <: Tuple
-        if Arrow.ntupleT(S) == UInt8
+        if Arrow.getT(S) == UInt8
             A = x.fielddata.DATA
             return Tuple(map(UInt8, collect(A[i])))
         else
             sz = x.field.type.listSize
-            A = ArrowArray{Arrow.ntupleT(S)}(x.field.children[1], x.fielddata.children[1], x.dictionaries)
+            A = ArrowArray{Arrow.getT(S)}(x.field.children[1], x.fielddata.children[1], x.dictionaries)
             off = (i - 1) * sz + 1
             return Tuple(A[off:(off + sz - 1)])
         end
     elseif S <: NamedTuple
         data = (ArrowArray(x.field.children[j], x.fielddata.children[j], x.dictionaries)[i] for j = 1:length(x.field.children))
-        return NamedTuple{Arrow.ntnames(S)}(Tuple(data))
+        return NamedTuple{Arrow.getnames(S)}(Tuple(data))
     elseif S == Int64 || S == UInt64
         return parse(S, x.fielddata.DATA[i])
     elseif S <: Arrow.Decimal

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,9 +12,8 @@ include("testtables.jl")
 
 @testset "table roundtrips" begin
 
-for (nm, tbl, writekw, readkw, extratests) in testtables
-    println(nm)
-    testtable(tbl, writekw, readkw, extratests)
+for case in testtables
+    testtable(case...)
 end
 
 end # @testset "table roundtrips"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,145 +1,28 @@
 using Test, Arrow, Tables, Dates, PooledArrays
 
-struct MapTable
-    x
+if isdefined(Tables, :partitioner)
+    partitioner = Tables.partitioner
+else
+    partitioner = Tuple
 end
-Tables.columnnames(x::MapTable) = propertynames(x.x)
-Tables.getcolumn(x::MapTable, i::Int) = getfield(x.x, i)
-Tables.getcolumn(x::MapTable, nm::Symbol) = getproperty(x.x, nm)
-Tables.schema(x::MapTable) = Tables.Schema(propertynames(x.x), eltype.(getproperty(x.x, nm) for nm in propertynames(x.x)))
-Tables.columns(x::MapTable) = x
+
+include("testtables.jl")
 
 @testset "Arrow" begin
 
-# basic
-t = (col1=Int64[1,2,3,4,5,6,7,8,9,10],)
-io = IOBuffer()
-Arrow.write(io, t)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test tt.col1 == t.col1
-@test eltype(tt.col1) === Int64
-col1 = copy(tt.col1)
-@test typeof(col1) == Vector{Int64}
+@testset "table roundtrips" begin
 
-# missing values
-t = (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],)
-io = IOBuffer()
-Arrow.write(io, t)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test isequal(tt.col1, t.col1)
-@test eltype(tt.col1) === Union{Int64, Missing}
+for (nm, tbl, writekw, readkw, extratests) in testtables
+    println(nm)
+    testtable(tbl, writekw, readkw, extratests)
+end
 
-# primitive types
-t = (
-    col1=[missing, missing, missing, missing],
-    col2=Union{UInt8, Missing}[0, 1, 2, missing],
-    col3=Union{UInt16, Missing}[0, 1, 2, missing],
-    col4=Union{UInt32, Missing}[0, 1, 2, missing],
-    col5=Union{UInt64, Missing}[0, 1, 2, missing],
-    col6=Union{Int8, Missing}[0, 1, 2, missing],
-    col7=Union{Int16, Missing}[0, 1, 2, missing],
-    col8=Union{Int32, Missing}[0, 1, 2, missing],
-    col9=Union{Int64, Missing}[0, 1, 2, missing],
-    col10=Union{Float16, Missing}[0, 1, 2, missing],
-    col11=Union{Float32, Missing}[0, 1, 2, missing],
-    col12=Union{Float64, Missing}[0, 1, 2, missing],
-    col13=[true, false, true, missing],
-)
-io = IOBuffer()
-Arrow.write(io, t)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
+end # @testset "table roundtrips"
 
-t = (
-    col14=[zero(Arrow.Decimal{Int32(2), Int32(2)}), zero(Arrow.Decimal{Int32(2), Int32(2)}), zero(Arrow.Decimal{Int32(2), Int32(2)}), missing],
-    col15=[zero(Arrow.Date{Arrow.Meta.DateUnit.DAY, Int32}), zero(Arrow.Date{Arrow.Meta.DateUnit.DAY, Int32}), zero(Arrow.Date{Arrow.Meta.DateUnit.DAY, Int32}), missing],
-    col16=[zero(Arrow.Time{Arrow.Meta.TimeUnit.SECOND, Int32}), zero(Arrow.Time{Arrow.Meta.TimeUnit.SECOND, Int32}), zero(Arrow.Time{Arrow.Meta.TimeUnit.SECOND, Int32}), missing],
-    col17=[zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), missing],
-    col18=[zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), missing],
-    col19=[zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), missing],
-)
-io = IOBuffer()
-Arrow.write(io, t)
-seekstart(io)
-tt = Arrow.Table(io; convert=false)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
-# list types
-t = (
-    col1=Union{String, Missing}["hey", "there", "sailor", missing],
-    col2=Union{Vector{UInt8}, Missing}[b"hey", b"there", b"sailor", missing],
-    col3=Union{Vector{Int64}, Missing}[Int64[1], Int64[2], Int64[3], missing],
-    col4=Union{NTuple{2, Vector{Int64}},Missing}[(Int64[1], Int64[2]), missing, missing, (Int64[3], Int64[4])],
-    col5=Union{NTuple{2, UInt8}, Missing}[(0x01, 0x02), (0x03, 0x04), missing, (0x05, 0x06)],
-    col6=NamedTuple{(:a, :b), Tuple{Int64, String}}[(a=Int64(1), b="hey"), (a=Int64(2), b="there"), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")],
-)
-io = IOBuffer()
-Arrow.write(io, t)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
-# unions
-t = (
-    col1=Arrow.DenseUnionVector([1, 2.0, 3, 4.0, missing]),
-    col2=Arrow.SparseUnionVector([1, 2.0, 3, 4.0, missing]),
-)
-io = IOBuffer()
-Arrow.write(io, t)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
-# dict encodings
-t = (
-    col1=Arrow.DictEncode(Int64[4, 5, 6]),
-)
-io = IOBuffer()
-Arrow.write(io, t; debug=true)
-seekstart(io)
-tt = Arrow.Table(io; debug=true)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-col1 = copy(tt.col1)
-@test typeof(col1) == PooledVector{Int64, Int8, Vector{Int8}}
-
-t = (
-    col1=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
-)
-io = IOBuffer()
-Arrow.write(io, t; debug=true)
-seekstart(io)
-tt = Arrow.Table(io; debug=true)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
-# PooledArrays
-t = (
-    col1=PooledArray([4,5,6,6]),
-)
-io = IOBuffer()
-Arrow.write(io, t; debug=true)
-seekstart(io)
-tt = Arrow.Table(io; debug=true)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
+@testset "misc" begin
 
 # multiple record batches
-if isdefined(Tables, :partitioner)
-    xx = Tables.partitioner
-else
-    xx = Tuple
-end
-t = xx(((col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],), (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],)))
+t = partitioner(((col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],), (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],)))
 io = IOBuffer()
 Arrow.write(io, t)
 seekstart(io)
@@ -148,65 +31,6 @@ tt = Arrow.Table(io)
 @test isequal(tt.col1, vcat([1,2,3,4,5,6,7,8,9,missing], [1,2,3,4,5,6,7,8,9,missing]))
 @test eltype(tt.col1) === Union{Int64, Missing}
 
-# auto-converting types
-t = (
-    col1=[Date(2001, 1, 2), Date(2010, 10, 10), Date(2020, 12, 1)],
-    col2=[Time(1, 1, 2), Time(13, 10, 10), Time(22, 12, 1)],
-    col3=[DateTime(2001, 1, 2), DateTime(2010, 10, 10), DateTime(2020, 12, 1)]
-)
-io = IOBuffer()
-Arrow.write(io, t; debug=true)
-seekstart(io)
-tt = Arrow.Table(io; debug=true)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
-# Map
-t = MapTable((
-    col1=Dict(Int32(1) => Float32(3.14)),
-))
-io = IOBuffer()
-Arrow.write(io, t; debug=true)
-seekstart(io)
-tt = Arrow.Table(io; debug=true)
-for (k, v) in tt.col1
-    @test isequal(t.x.col1[k], v)
-end
-
-# file format
-t = (
-    col1=[missing, missing, missing, missing],
-    col2=Union{UInt8, Missing}[0, 1, 2, missing],
-    col3=Union{UInt16, Missing}[0, 1, 2, missing],
-    col4=Union{UInt32, Missing}[0, 1, 2, missing],
-    col5=Union{UInt64, Missing}[0, 1, 2, missing],
-    col6=Union{Int8, Missing}[0, 1, 2, missing],
-    col7=Union{Int16, Missing}[0, 1, 2, missing],
-    col8=Union{Int32, Missing}[0, 1, 2, missing],
-    col9=Union{Int64, Missing}[0, 1, 2, missing],
-    col10=Union{Float16, Missing}[0, 1, 2, missing],
-    col11=Union{Float32, Missing}[0, 1, 2, missing],
-    col12=Union{Float64, Missing}[0, 1, 2, missing],
-    col13=[true, false, true, missing],
-)
-io = IOBuffer()
-Arrow.write(io, t; file=true)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
-# non-standard types
-t = (
-    col1=[:hey, :there, :sailor],
-    col2=['a', 'b', 'c'],
-)
-io = IOBuffer()
-Arrow.write(io, t)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
 
 t = (col1=Int64[1,2,3,4,5,6,7,8,9,10],)
 meta = Dict("key1" => "value1", "key2" => "value2")
@@ -223,31 +47,6 @@ tt = Arrow.Table(io)
 @test Arrow.getmetadata(tt) == meta
 @test Arrow.getmetadata(tt.col1) == meta2
 
-t = (
-    col1=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
-)
-io = IOBuffer()
-Arrow.write(io, t; debug=true)
-seekstart(io)
-tt = Arrow.Table(io; debug=true)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
-# large lists
-t = (
-    col1=Union{String, Missing}["hey", "there", "sailor", missing],
-    col2=Union{Vector{UInt8}, Missing}[b"hey", b"there", b"sailor", missing],
-    col3=Union{Vector{Int64}, Missing}[Int64[1], Int64[2], Int64[3], missing],
-    col4=Union{NTuple{2, Vector{Int64}},Missing}[(Int64[1], Int64[2]), missing, missing, (Int64[3], Int64[4])],
-    col5=Union{NTuple{2, UInt8}, Missing}[(0x01, 0x02), (0x03, 0x04), missing, (0x05, 0x06)],
-    col6=NamedTuple{(:a, :b), Tuple{Int64, String}}[(a=Int64(1), b="hey"), (a=Int64(2), b="there"), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")],
-)
-io = IOBuffer()
-Arrow.write(io, t; largelists=true)
-seekstart(io)
-tt = Arrow.Table(io)
-@test length(tt) == length(t)
-@test all(isequal.(values(t), values(tt)))
-
+end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,5 @@
 using Test, Arrow, Tables, Dates, PooledArrays
 
-if isdefined(Tables, :partitioner)
-    partitioner = Tables.partitioner
-else
-    partitioner = Tuple
-end
-
 include("testtables.jl")
 
 @testset "Arrow" begin
@@ -21,7 +15,7 @@ end # @testset "table roundtrips"
 @testset "misc" begin
 
 # multiple record batches
-t = partitioner(((col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],), (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],)))
+t = Tables.partitioner(((col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],), (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],)))
 io = IOBuffer()
 Arrow.write(io, t)
 seekstart(io)

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -1,0 +1,208 @@
+testtables = [
+  (
+    "basic",
+    (col1=Int64[1,2,3,4,5,6,7,8,9,10],),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "missing values",
+    (col1=Union{Int64, Missing}[1,2,3,4,5,6,7,8,9,missing],),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "primitive types",
+    (
+      col1=[missing, missing, missing, missing],
+      col2=Union{UInt8, Missing}[0, 1, 2, missing],
+      col3=Union{UInt16, Missing}[0, 1, 2, missing],
+      col4=Union{UInt32, Missing}[0, 1, 2, missing],
+      col5=Union{UInt64, Missing}[0, 1, 2, missing],
+      col6=Union{Int8, Missing}[0, 1, 2, missing],
+      col7=Union{Int16, Missing}[0, 1, 2, missing],
+      col8=Union{Int32, Missing}[0, 1, 2, missing],
+      col9=Union{Int64, Missing}[0, 1, 2, missing],
+      col10=Union{Float16, Missing}[0, 1, 2, missing],
+      col11=Union{Float32, Missing}[0, 1, 2, missing],
+      col12=Union{Float64, Missing}[0, 1, 2, missing],
+      col13=[true, false, true, missing],
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "arrow date/time types",
+    (
+      col14=[zero(Arrow.Decimal{Int32(2), Int32(2)}), zero(Arrow.Decimal{Int32(2), Int32(2)}), zero(Arrow.Decimal{Int32(2), Int32(2)}), missing],
+      col15=[zero(Arrow.Date{Arrow.Meta.DateUnit.DAY, Int32}), zero(Arrow.Date{Arrow.Meta.DateUnit.DAY, Int32}), zero(Arrow.Date{Arrow.Meta.DateUnit.DAY, Int32}), missing],
+      col16=[zero(Arrow.Time{Arrow.Meta.TimeUnit.SECOND, Int32}), zero(Arrow.Time{Arrow.Meta.TimeUnit.SECOND, Int32}), zero(Arrow.Time{Arrow.Meta.TimeUnit.SECOND, Int32}), missing],
+      col17=[zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), missing],
+      col18=[zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), missing],
+      col19=[zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), missing],
+    ),
+    NamedTuple(),
+    (convert=false,),
+    nothing
+  ),
+  (
+    "list types",
+    (
+      col1=Union{String, Missing}["hey", "there", "sailor", missing],
+      col2=Union{Vector{UInt8}, Missing}[b"hey", b"there", b"sailor", missing],
+      col3=Union{Vector{Int64}, Missing}[Int64[1], Int64[2], Int64[3], missing],
+      col4=Union{NTuple{2, Vector{Int64}},Missing}[(Int64[1], Int64[2]), missing, missing, (Int64[3], Int64[4])],
+      col5=Union{NTuple{2, UInt8}, Missing}[(0x01, 0x02), (0x03, 0x04), missing, (0x05, 0x06)],
+      col6=NamedTuple{(:a, :b), Tuple{Int64, String}}[(a=Int64(1), b="hey"), (a=Int64(2), b="there"), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")],
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "unions",
+    (
+      col1=Arrow.DenseUnionVector([1, 2.0, 3, 4.0, missing]),
+      col2=Arrow.SparseUnionVector([1, 2.0, 3, 4.0, missing]),
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "dict encodings",
+    (
+      col1=Arrow.DictEncode(Int64[4, 5, 6]),
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    function (tt)
+      col1 = copy(tt.col1)
+      @test typeof(col1) == PooledVector{Int64, Int8, Vector{Int8}}
+    end
+  ),
+  (
+    "more dict encodings",
+    (
+      col1=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "PooledArray",
+    (
+      col1=PooledArray([4,5,6,6]),
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "auto-converting types",
+    (
+      col1=[Date(2001, 1, 2), Date(2010, 10, 10), Date(2020, 12, 1)],
+      col2=[Time(1, 1, 2), Time(13, 10, 10), Time(22, 12, 1)],
+      col3=[DateTime(2001, 1, 2), DateTime(2010, 10, 10), DateTime(2020, 12, 1)]
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "Map",
+    (
+      col1=[Dict(Int32(1) => Float32(3.14)), missing],
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "non-standard types",
+    (
+      col1=[:hey, :there, :sailor],
+      col2=['a', 'b', 'c'],
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "large lists",
+    (
+      col1=Union{String, Missing}["hey", "there", "sailor", missing],
+      col2=Union{Vector{UInt8}, Missing}[b"hey", b"there", b"sailor", missing],
+      col3=Union{Vector{Int64}, Missing}[Int64[1], Int64[2], Int64[3], missing],
+      col4=Union{NTuple{2, Vector{Int64}},Missing}[(Int64[1], Int64[2]), missing, missing, (Int64[3], Int64[4])],
+      col5=Union{NTuple{2, UInt8}, Missing}[(0x01, 0x02), (0x03, 0x04), missing, (0x05, 0x06)],
+      col6=NamedTuple{(:a, :b), Tuple{Int64, String}}[(a=Int64(1), b="hey"), (a=Int64(2), b="there"), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")],
+    ),
+    (largelists=true,),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "dictencode keyword",
+    (
+      col1=Int64[1,2,3,4,5,6,7,8,9,10],
+      col2=Union{String, Missing}["hey", "there", "sailor", missing],
+      col3=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
+    ),
+    (dictencode=true,),
+    NamedTuple(),
+    nothing
+  ),
+  (
+    "nesteddictencode keyword",
+    (
+      col1=Int64[1,2,3,4],
+      col2=Union{String, Missing}["hey", "there", "sailor", missing],
+      col3=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
+    ),
+    (dictencodenested=true,),
+    NamedTuple(),
+    nothing
+  ),
+  # (
+  #   "Julia unions",
+  #   (
+  #     col1=Union{Int, String}[1, "hey", 2, "ho"],
+  #     col2=Union{Char, NamedTuple{(:a,), Tuple{Symbol}}}['a', (a=:hey,), 'b', (a=:ho,)],
+  #   ),
+  #   (denseunions=false,),
+  #   NamedTuple(),
+  #   nothing
+  # ),
+];
+
+function testtable(t, writekw, readkw, extratests)
+  io = IOBuffer()
+  Arrow.write(io, t; writekw...)
+  seekstart(io)
+  tt = Arrow.Table(io; readkw...)
+  @test length(tt) == length(t)
+  @test all(isequal.(values(t), values(tt)))
+  extratests !== nothing && extratests(tt)
+  # compressed
+  io = IOBuffer()
+  Arrow.write(io, t; compress=rand((:lz4, :zstd)), writekw...)
+  seekstart(io)
+  tt = Arrow.Table(io; readkw...)
+  @test length(tt) == length(t)
+  @test all(isequal.(values(t), values(tt)))
+  extratests !== nothing && extratests(tt)
+  # file
+  io = IOBuffer()
+  Arrow.write(io, t; file=true, writekw...)
+  seekstart(io)
+  tt = Arrow.Table(io; readkw...)
+  @test length(tt) == length(t)
+  @test all(isequal.(values(t), values(tt)))
+  extratests !== nothing && extratests(tt)
+  return
+end

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -127,6 +127,7 @@ testtables = [
     (
       col1=[:hey, :there, :sailor],
       col2=['a', 'b', 'c'],
+      col3=Arrow.DictEncode(['a', 'a', 'b'])
     ),
     NamedTuple(),
     NamedTuple(),
@@ -152,6 +153,8 @@ testtables = [
       col1=Int64[1,2,3,4,5,6,7,8,9,10],
       col2=Union{String, Missing}["hey", "there", "sailor", missing],
       col3=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
+      col4=[:a, :b, :c, :d, :a, :b, :c, :d, :e, missing],
+      col5=[Date(2020, 1, 1) for x = 1:10]
     ),
     (dictencode=true,),
     NamedTuple(),
@@ -168,16 +171,16 @@ testtables = [
     NamedTuple(),
     nothing
   ),
-  # (
-  #   "Julia unions",
-  #   (
-  #     col1=Union{Int, String}[1, "hey", 2, "ho"],
-  #     col2=Union{Char, NamedTuple{(:a,), Tuple{Symbol}}}['a', (a=:hey,), 'b', (a=:ho,)],
-  #   ),
-  #   (denseunions=false,),
-  #   NamedTuple(),
-  #   nothing
-  # ),
+  (
+    "Julia unions",
+    (
+      col1=Union{Int, String}[1, "hey", 2, "ho"],
+      col2=Union{Char, NamedTuple{(:a,), Tuple{Symbol}}}['a', (a=:hey,), 'b', (a=:ho,)],
+    ),
+    (denseunions=false,),
+    NamedTuple(),
+    nothing
+  ),
 ];
 
 function testtable(nm, t, writekw, readkw, extratests)

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -164,7 +164,7 @@ testtables = [
       col2=Union{String, Missing}["hey", "there", "sailor", missing],
       col3=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
     ),
-    (dictencodenested=true,),
+    (dictencode=true, dictencodenested=true,),
     NamedTuple(),
     nothing
   ),
@@ -180,7 +180,8 @@ testtables = [
   # ),
 ];
 
-function testtable(t, writekw, readkw, extratests)
+function testtable(nm, t, writekw, readkw, extratests)
+  println("testing: $nm")
   io = IOBuffer()
   Arrow.write(io, t; writekw...)
   seekstart(io)
@@ -190,7 +191,7 @@ function testtable(t, writekw, readkw, extratests)
   extratests !== nothing && extratests(tt)
   # compressed
   io = IOBuffer()
-  Arrow.write(io, t; compress=rand((:lz4, :zstd)), writekw...)
+  Arrow.write(io, t; compress=((:lz4, :zstd)[rand(1:2)]), writekw...)
   seekstart(io)
   tt = Arrow.Table(io; readkw...)
   @test length(tt) == length(t)


### PR DESCRIPTION
In particular this PR:
  * Changes the flow of writing so that input columns are converted to
  their "arrow" equivalent, most of the time lazily, so that the actual
  writing is much simpler and just deals with each array type
  * Introduces an ArrowTypes module that defines the ArrowType trait,
  which types can overload to signal what kind of arrow type they should
  be converted to. This isn't super fleshed out quite yet as we need to
  figure out the acutal requirements for the different arrow types, but
  it's a start
  * Support reading/writing compressed arrow buffers automatically
  (reading) and via keyword arg (writing, `compress=:lz4` or
  `compress=:zstd`
  * support nested dict encoding (fixes #15)
  * fixes #24; not exactly sure what the issue was, but it doesn't
  happen on this branch
  * reorganizes tests so that for each kind of "table", we do IPC test,
  compressed buffers test, and file test
  * support for nesting "special" types like `Char`/`Symbol`; previously they were only allowed as top-level columns, but now they can appear in NamedTuple, vector of vectors, etc.
  * Fix the `Map` type; I mistakenly thought `Map` meant that each element of the column was a `Pair`, but it actually means each element is a `Dict`. So it's more similar to the `List` type than `Struct`; this fixes the reading/writing for this type.
  * ensure array types that need hold a reference to their `unsafe_wrap`ed bytes; these bytes may be from the original arrow blob or an uncompressed buffer