### PR TITLE
Refactor nested dict encoding and isdelta dictionary batch support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
-authors = ["quinnj <quinn.jacobd@gmail.com>", "ExpandingMan <expandingman@protonmail.com"]
+authors = ["quinnj <quinn.jacobd@gmail.com>"]
 version = "0.3.0"
 
 [deps]

--- a/src/arraytypes/bool.jl
+++ b/src/arraytypes/bool.jl
@@ -44,7 +44,7 @@ end
     return v
 end
 
-function arrowvector(::BoolType, x, de, meta; kw...)
+function arrowvector(::BoolType, x, i, nl, fi, de, ded, meta; kw...)
     validity = ValidityBitmap(x)
     len = length(x)
     blen = cld(len, 8)

--- a/src/arraytypes/fixedsizelist.jl
+++ b/src/arraytypes/fixedsizelist.jl
@@ -83,14 +83,14 @@ end
     return x, (i + 1, chunk, chunk_i, len)
 end
 
-function arrowvector(::FixedSizeListType, x, de, meta; kw...)
+function arrowvector(::FixedSizeListType, x, i, nl, fi, de, ded, meta; kw...)
     len = length(x)
     validity = ValidityBitmap(x)
     flat = ToFixedSizeList(x)
     if eltype(flat) == UInt8
         data = flat
     else
-        data = arrowvector(flat, de, nothing; kw...)
+        data = arrowvector(flat, i, nl + 1, fi, de, ded, nothing; kw...)
     end
     return FixedSizeList{eltype(x), typeof(data)}(UInt8[], validity, data, len, meta)
 end

--- a/src/arraytypes/list.jl
+++ b/src/arraytypes/list.jl
@@ -173,7 +173,7 @@ end
     return x, (i, chunk, chunk_i, chunk_len, len)
 end
 
-function arrowvector(::ListType, x, de, meta; largelists::Bool=false, kw...)
+function arrowvector(::ListType, x, i, nl, fi, de, ded, meta; largelists::Bool=false, kw...)
     len = length(x)
     validity = ValidityBitmap(x)
     flat = ToList(x; largelists=largelists)
@@ -181,7 +181,7 @@ function arrowvector(::ListType, x, de, meta; largelists::Bool=false, kw...)
     if eltype(flat) == UInt8 # binary or utf8string
         data = flat
     else
-        data = arrowvector(flat, de, nothing; lareglists=largelists, kw...)
+        data = arrowvector(flat, i, nl + 1, fi, de, ded, nothing; lareglists=largelists, kw...)
     end
     return List{eltype(x), eltype(flat.inds), typeof(data)}(UInt8[], validity, offsets, data, len, meta)
 end

--- a/src/arraytypes/map.jl
+++ b/src/arraytypes/map.jl
@@ -37,7 +37,7 @@ end
 keyvalues(KT, ::Missing) = missing
 keyvalues(KT, x::AbstractDict) = [KT(k, v) for (k, v) in pairs(x)]
 
-function arrowvector(::MapType, x, de, meta; largelists::Bool=false, kw...)
+function arrowvector(::MapType, x, i, nl, fi, de, ded, meta; largelists::Bool=false, kw...)
     len = length(x)
     validity = ValidityBitmap(x)
     ET = eltype(x)
@@ -47,7 +47,7 @@ function arrowvector(::MapType, x, de, meta; largelists::Bool=false, kw...)
     T = DT !== ET ? Union{Missing, VT} : VT
     flat = ToList(T[keyvalues(KT, y) for y in x]; largelists=largelists)
     offsets = Offsets(UInt8[], flat.inds)
-    data = arrowvector(flat, de, nothing; lareglists=largelists, kw...)
+    data = arrowvector(flat, i, nl + 1, fi, de, ded, nothing; lareglists=largelists, kw...)
     return Map{ET, eltype(flat.inds), typeof(data)}(validity, offsets, data, len, meta)
 end
 

--- a/src/arraytypes/primitive.jl
+++ b/src/arraytypes/primitive.jl
@@ -58,7 +58,7 @@ end
     return v
 end
 
-function arrowvector(::PrimitiveType, x, de, meta; kw...)
+function arrowvector(::PrimitiveType, x, i, nl, fi, de, ded, meta; kw...)
     validity = ValidityBitmap(x)
     return Primitive(eltype(x), UInt8[], validity, x, length(x), meta)
 end

--- a/src/arraytypes/struct.jl
+++ b/src/arraytypes/struct.jl
@@ -67,14 +67,14 @@ Base.size(x::ToStruct) = (length(x.data),)
 Base.@propagate_inbounds function Base.getindex(A::ToStruct{T, j}, i::Integer) where {T, j}
     @boundscheck checkbounds(A, i)
     @inbounds x = A.data[i]
-    return @miss_or(x, @inbounds getfield(x, j))
+    return x === missing ? ArrowTypes.default(T) : getfield(x, j)
 end
 
-function arrowvector(::StructType, x, de, meta; kw...)
+function arrowvector(::StructType, x, i, nl, fi, de, ded, meta; kw...)
     len = length(x)
     validity = ValidityBitmap(x)
     T = Base.nonmissingtype(eltype(x))
-    data = Tuple(arrowvector(ToStruct(x, i), de, nothing; kw...) for i = 1:fieldcount(T))
+    data = Tuple(arrowvector(ToStruct(x, j), i, nl + 1, j, de, ded, nothing; kw...) for j = 1:fieldcount(T))
     return Struct{eltype(x), typeof(data)}(validity, data, len, meta)
 end
 

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -95,6 +95,7 @@ default(T) = zero(T)
 default(::Type{Symbol}) = Symbol()
 default(::Type{Char}) = '\0'
 default(::Type{String}) = ""
+default(::Type{Union{T, Missing}}) where {T} = default(T)
 
 function default(::Type{A}) where {A <: AbstractVector{T}} where {T}
     a = similar(A, 1)

--- a/src/metadata/Message.jl
+++ b/src/metadata/Message.jl
@@ -127,8 +127,8 @@ function Base.getproperty(x::DictionaryBatch, field::Symbol)
             return FlatBuffers.init(RecordBatch, FlatBuffers.bytes(x), y)
         end
     elseif field === :isDelta
-        o = FlatBuffers.offset(x, 4)
-        o != 0 && return FlatBuffers.get(x, o + FlatBuffers.pos(x), Bool)
+        o = FlatBuffers.offset(x, 8)
+        o != 0 && return FlatBuffers.get(x, o + FlatBuffers.pos(x), Base.Bool)
         return false
     end
     return nothing

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -156,3 +156,64 @@ function readmessage(filebytes, off=9)
 
     FlatBuffers.getrootas(Meta.Message, filebytes, off + 8)
 end
+
+# a custom Channel type that only allows put!-ing objects in a specific, monotonically increasing order
+struct OrderedChannel{T}
+    chan::Channel{T}
+    cond::Threads.Condition
+    i::Ref{Int}
+end
+
+OrderedChannel{T}(sz) where {T} = OrderedChannel{T}(Channel{T}(sz), Threads.Condition(), Ref(1))
+Base.iterate(ch::OrderedChannel, st...) = iterate(ch.chan, st...)
+
+macro lock(obj, expr)
+    esc(quote
+        lock($obj)
+        try
+            $expr
+        finally
+            unlock($obj)
+        end
+    end)
+end
+
+# when put!-ing an object, operation may have to wait until other tasks have put their
+# objects to ensure the channel is ordered correctly
+function Base.put!(ch::OrderedChannel{T}, x::T, i::Integer, incr::Bool=false) where {T}
+    @lock ch.cond begin
+        while ch.i[] < i
+            # channel index too early, need to wait for other tasks to put their objects first
+            wait(ch.cond)
+        end
+        # now it's our turn
+        put!(ch.chan, x)
+        if incr
+            ch.i[] += 1
+        end
+        # wake up tasks that may be waiting to put their objects
+        notify(ch.cond)
+    end
+    return
+end
+
+function Base.close(ch::OrderedChannel)
+    @lock ch.cond begin
+        # just need to ensure any tasks waiting to put their tasks have had a chance to put
+        while Base.n_waiters(ch.cond) > 0
+            wait(ch.cond)
+        end
+        close(ch.chan)
+    end
+    return
+end
+
+struct Lockable{T}
+    x::T
+    lock::ReentrantLock
+end
+
+Lockable(x::T) where {T} = Lockable{T}(x, ReentrantLock())
+
+Base.lock(x::Lockable) = lock(x.lock)
+Base.unlock(x::Lockable) = unlock(x.lock)

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -179,9 +179,7 @@ testtables = [
   (
     "nesteddictencode keyword",
     (
-      col1=Int64[1,2,3,4],
-      col2=Union{String, Missing}["hey", "there", "sailor", missing],
-      col3=Arrow.DictEncode(NamedTuple{(:a, :b), Tuple{Int64, Union{String, Missing}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b="sailor"), (a=Int64(4), b="jo-bob")]),
+      col1=NamedTuple{(:a, :b), Tuple{Int64, Union{Missing, NamedTuple{(:c,), Tuple{String}}}}}[(a=Int64(1), b=missing), (a=Int64(1), b=missing), (a=Int64(3), b=(c="sailor",)), (a=Int64(4), b=(c="jo-bob",))],
     ),
     (dictencode=true, dictencodenested=true,),
     NamedTuple(),


### PR DESCRIPTION
Fixes #32 among other issues. Turns out the probably-rare-in-practice
data race mentioned in #32 was the least of the worries. While digging
into things, I realized we weren't doing isDelta dictionary batches
right at all. In particular, we were basically writing each record
batch/dictionary batch independent of each other, but using the same
dictionary batch ids. We didn't have tests failures because we weren't
testing isDelta batches anyway :P.

In this PR, everything is cleaned up quite a bit. We now generate a
dictionary encoding id based on the column index, nesting level, and
field index (in the case of structs and unions). This allows us to
re-use the same constructed dict encodings from batch to batch, and also
allows us to support the use-case of re-using a single dict encoding
across multiple columns if so desired (user would just pass in their own
`DictEncode` column pointing to the same id). We also avoid race
conditions by putting a lock around dict encodings so different threads
writing will have to take turns.