### PR TITLE
Pass "ArrowVector" through arrowvector calls

### DIFF
--- a/src/arraytypes/bool.jl
+++ b/src/arraytypes/bool.jl
@@ -44,6 +44,8 @@ end
     return v
 end
 
+arrowvector(::BoolType, x::BoolVector, i, nl, fi, de, ded, meta; kw...) = x
+
 function arrowvector(::BoolType, x, i, nl, fi, de, ded, meta; kw...)
     validity = ValidityBitmap(x)
     len = length(x)

--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -75,6 +75,8 @@ dictencodeid(colidx, nestedlevel, fieldid) = (Int64(nestedlevel) << 48) | (Int64
 getid(d::DictEncoded) = d.encoding.id
 getid(c::Compressed{Z, A}) where {Z, A <: DictEncoded} = c.data.encoding.id
 
+arrowvector(::DictEncodedType, x::DictEncoded, i, nl, fi, de, ded, meta; kw...) = x
+
 function arrowvector(::DictEncodedType, x, i, nl, fi, de, ded, meta; dictencode::Bool=false, dictencodenested::Bool=false, kw...)
     @assert x isa DictEncode
     id = x.id == -1 ? dictencodeid(i, nl, fi) : x.id

--- a/src/arraytypes/fixedsizelist.jl
+++ b/src/arraytypes/fixedsizelist.jl
@@ -83,6 +83,8 @@ end
     return x, (i + 1, chunk, chunk_i, len)
 end
 
+arrowvector(::FixedSizeListType, x::FixedSizeList, i, nl, fi, de, ded, meta; kw...) = x
+
 function arrowvector(::FixedSizeListType, x, i, nl, fi, de, ded, meta; kw...)
     len = length(x)
     validity = ValidityBitmap(x)

--- a/src/arraytypes/list.jl
+++ b/src/arraytypes/list.jl
@@ -173,6 +173,8 @@ end
     return x, (i, chunk, chunk_i, chunk_len, len)
 end
 
+arrowvector(::ListType, x::List, i, nl, fi, de, ded, meta; kw...) = x
+
 function arrowvector(::ListType, x, i, nl, fi, de, ded, meta; largelists::Bool=false, kw...)
     len = length(x)
     validity = ValidityBitmap(x)

--- a/src/arraytypes/map.jl
+++ b/src/arraytypes/map.jl
@@ -37,6 +37,8 @@ end
 keyvalues(KT, ::Missing) = missing
 keyvalues(KT, x::AbstractDict) = [KT(k, v) for (k, v) in pairs(x)]
 
+arrowvector(::MapType, x::Map, i, nl, fi, de, ded, meta; kw...) = x
+
 function arrowvector(::MapType, x, i, nl, fi, de, ded, meta; largelists::Bool=false, kw...)
     len = length(x)
     validity = ValidityBitmap(x)

--- a/src/arraytypes/primitive.jl
+++ b/src/arraytypes/primitive.jl
@@ -58,6 +58,8 @@ end
     return v
 end
 
+arrowvector(::PrimitiveType, x::Primitive, i, nl, fi, de, ded, meta; kw...) = x
+
 function arrowvector(::PrimitiveType, x, i, nl, fi, de, ded, meta; kw...)
     validity = ValidityBitmap(x)
     return Primitive(eltype(x), UInt8[], validity, x, length(x), meta)

--- a/src/arraytypes/struct.jl
+++ b/src/arraytypes/struct.jl
@@ -70,6 +70,8 @@ Base.@propagate_inbounds function Base.getindex(A::ToStruct{T, j}, i::Integer) w
     return x === missing ? ArrowTypes.default(T) : getfield(x, j)
 end
 
+arrowvector(::StructType, x::Struct, i, nl, fi, de, ded, meta; kw...) = x
+
 function arrowvector(::StructType, x, i, nl, fi, de, ded, meta; kw...)
     len = length(x)
     validity = ValidityBitmap(x)


### PR DESCRIPTION
If users construct `ArrowVector` types themselves, or read, then write,
we can be a bit more efficient by not making copies.