### PR TITLE
Add TimeZones dependency for auto-converting Timestamp

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [compat]
 CodecLz4 = "0.4"

--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -42,7 +42,7 @@ module Arrow
 
 using Mmap
 import Dates
-using DataAPI, Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd
+using DataAPI, Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd, TimeZones
 
 using Base: @propagate_inbounds
 import Base: ==

--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -51,6 +51,8 @@ arrowvector(::Type{Dates.Time}, x, i, nl, fi, de, ded, meta; kw...) =
     arrowvector(converter(TIME, x), i, nl, fi, de, ded, meta; kw...)
 arrowvector(::Type{Dates.DateTime}, x, i, nl, fi, de, ded, meta; kw...) =
     arrowvector(converter(DATETIME, x), i, nl, fi, de, ded, meta; kw...)
+arrowvector(::Type{ZonedDateTime}, x, i, nl, fi, de, ded, meta; kw...) =
+    arrowvector(converter(Timestamp{Meta.TimeUnit.MILLISECOND, Symbol(x[1].timezone)}, x), i, nl, fi, de, ded, meta; kw...)
 arrowvector(::Type{P}, x, i, nl, fi, de, ded, meta; kw...) where {P <: Dates.Period} =
     arrowvector(converter(Duration{arrowperiodtype(P)}, x), i, nl, fi, de, ded, meta; kw...)
 

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -227,9 +227,11 @@ function juliaeltype(f::Meta.Field, x::Meta.Timestamp, convert)
     return Timestamp{x.unit, x.timezone === nothing ? nothing : Symbol(x.timezone)}
 end
 
-finaljuliatype(::Type{Timestamp{U, nothing}}) where {U} = Dates.DateTime
-Base.convert(::Type{Dates.DateTime}, x::Timestamp{U, nothing}) where {U} =
-    Dates.DateTime(Dates.UTM(Int64(Dates.toms(periodtype(U)(x.x)) + UNIX_EPOCH_DATETIME)))
+finaljuliatype(::Type{<:Timestamp}) = ZonedDateTime
+Base.convert(::Type{ZonedDateTime}, x::Timestamp{U, TZ}) where {U, TZ} =
+    ZonedDateTime(Dates.DateTime(Dates.UTM(Int64(Dates.toms(periodtype(U)(x.x)) + UNIX_EPOCH_DATETIME))), TimeZone(String(TZ)))
+Base.convert(::Type{Timestamp{Meta.TimeUnit.MILLISECOND, TZ}}, x::ZonedDateTime) where {TZ} =
+    Timestamp{Meta.TimeUnit.MILLISECOND, TZ}(Int64(Dates.value(DateTime(x, Local)) - UNIX_EPOCH_DATETIME))
 
 function arrowtype(b, ::Type{Timestamp{U, TZ}}) where {U, TZ}
     tz = TZ !== nothing ? FlatBuffers.createstring!(b, String(TZ)) : FlatBuffers.UOffsetT(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-using Test, Arrow, Tables, Dates, PooledArrays
+using Test, Arrow, Tables, Dates, PooledArrays, TimeZones
 
 include(joinpath(dirname(pathof(Arrow)), "../test/testtables.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/integrationtest.jl"))

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -123,7 +123,8 @@ testtables = [
     (
       col1=[Date(2001, 1, 2), Date(2010, 10, 10), Date(2020, 12, 1)],
       col2=[Time(1, 1, 2), Time(13, 10, 10), Time(22, 12, 1)],
-      col3=[DateTime(2001, 1, 2), DateTime(2010, 10, 10), DateTime(2020, 12, 1)]
+      col3=[DateTime(2001, 1, 2), DateTime(2010, 10, 10), DateTime(2020, 12, 1)],
+      col4=[ZonedDateTime(2001, 1, 2, TimeZone("America/Denver")), ZonedDateTime(2010, 10, 10, TimeZone("America/Denver")), ZonedDateTime(2020, 12, 1, TimeZone("America/Denver"))]
     ),
     NamedTuple(),
     NamedTuple(),


### PR DESCRIPTION
Implements #17. We now convert all Timestamp objects to ZonedDateTime
via auto-conversion (can be turned off by `convert=false`). The one
piece of awkwardness here is that it is currently assumed that with a
`Vector{ZonedDateTime}`, it is assumed that each element will have the
same timezone. Probably ok in practice, but frankly it'd be nicer if
there was a `ZonedDateTime` type that could be parameterized by the
timezone itself so that could be enforced via type parameter.

Also fixes #48. cc: @oxinabox, @kcajf, @omus 