### PR TITLE
Ensure any AbstractString is serialized correctly

### DIFF
--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -93,9 +93,8 @@ signedtype(::Type{UInt16}) = Int16
 signedtype(::Type{UInt32}) = Int32
 signedtype(::Type{UInt64}) = Int64
 
-indtype(d::D) where {D <: DictEncoded} = indtype(D)
-indtype(::Type{DictEncoded{T, S, A}}) where {T, S, A} = signedtype(S)
-indtype(c::Compressed{Z, A}) where {Z, A <: DictEncoded} = indtype(A)
+indtype(d::DictEncoded{T, S, A}) where {T, S, A} = S
+indtype(c::Compressed{Z, A}) where {Z, A <: DictEncoded} = indtype(c.data)
 
 dictencodeid(colidx, nestedlevel, fieldid) = (Int64(nestedlevel) << 48) | (Int64(fieldid) << 32) | Int64(colidx)
 
@@ -114,7 +113,7 @@ function arrowvector(::DictEncodedType, x, i, nl, fi, de, ded, meta; dictencode:
         # dict encoding doesn't exist yet, so create for 1st time
         if DataAPI.refarray(x) === x
             # need to encode ourselves
-            x = PooledArray(x)
+            x = PooledArray(x, encodingtype(length(x)))
             inds = DataAPI.refarray(x)
         else
             inds = copy(DataAPI.refarray(x))

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -98,7 +98,7 @@ function default end
 default(T) = zero(T)
 default(::Type{Symbol}) = Symbol()
 default(::Type{Char}) = '\0'
-default(::Type{String}) = ""
+default(::Type{<:AbstractString}) = ""
 default(::Type{Union{T, Missing}}) where {T} = default(T)
 
 function default(::Type{A}) where {A <: AbstractVector{T}} where {T}

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -295,7 +295,7 @@ end
 # arrowtype will call fieldoffset recursively for children
 function arrowtype(b, x::List{T, O, A}) where {T, O, A}
     if eltype(A) == UInt8
-        if T == String || T == Union{String, Missing}
+        if T <: AbstractString || T <: Union{AbstractString, Missing}
             if O == Int32
                 Meta.utf8Start(b)
                 return Meta.Utf8, Meta.utf8End(b), nothing

--- a/src/table.jl
+++ b/src/table.jl
@@ -53,7 +53,8 @@ end
 Tables.partitions(x::Stream) = x
 
 Stream(io::IO, pos::Integer=1, len=nothing; convert::Bool=true) = Stream(Base.read(io), pos, len; convert=convert)
-Stream(str::String, pos::Integer=1, len=nothing; convert::Bool=true) = Stream(Mmap.mmap(str), pos, len; convert=convert)
+Stream(str::String, pos::Integer=1, len=nothing; convert::Bool=true) = isfile(str) ? Stream(Mmap.mmap(str), pos, len; convert=convert) :
+    throw(ArgumentError("$str is not a valid arrow file"))
 
 # will detect whether we're reading a Stream from a file or stream
 function Stream(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothing}=nothing; convert::Bool=true)
@@ -175,7 +176,8 @@ Tables.getcolumn(t::Table, nm::Symbol) = lookup(t)[nm]
 
 # high-level user API functions
 Table(io::IO, pos::Integer=1, len=nothing; convert::Bool=true) = Table(Base.read(io), pos, len; convert=convert)
-Table(str::String, pos::Integer=1, len=nothing; convert::Bool=true) = Table(Mmap.mmap(str), pos, len; convert=convert)
+Table(str::String, pos::Integer=1, len=nothing; convert::Bool=true) = isfile(str) ? Table(Mmap.mmap(str), pos, len; convert=convert) :
+    throw(ArgumentError("$str is not a valid arrow file"))
 
 # will detect whether we're reading a Table from a file or stream
 function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothing}=nothing; convert::Bool=true)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -150,6 +150,13 @@ tt = Arrow.Table(io)
 # 49
 @test_throws ArgumentError Arrow.Table("file_that_doesnt_exist")
 
+# 52
+t = (a=Arrow.DictEncode(string.(1:129)),)
+io = IOBuffer()
+Arrow.write(io, t)
+seekstart(io)
+tt = Arrow.Table(io)
+
 end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,6 +147,9 @@ seekstart(io)
 tt = Arrow.Table(io)
 @test tt.a == ["aaaaaaaaaa", "aaaaaaaaaa"]
 
+# 49
+@test_throws ArgumentError Arrow.Table("file_that_doesnt_exist")
+
 end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,15 @@ tt = Arrow.Table(io)
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
 
+# 53
+s = "a" ^ 100
+t = (a=[SubString(s, 1:10), SubString(s, 11:20)],)
+io = IOBuffer()
+Arrow.write(io, t)
+seekstart(io)
+tt = Arrow.Table(io)
+@test tt.a == ["aaaaaaaaaa", "aaaaaaaaaa"]
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes #53. The issue here is we had a couple of spots where `String` was
hard-coded instead of checking if a type was `<: AbstractString`. This
lead to the original issue in #53 where `SubString{String}` was
serialized as "binary" instead of as a string.