### PR TITLE
Check field nullability for custom extension types

### DIFF
--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -131,11 +131,12 @@ const ARROW_TO_JULIA_TYPE_MAPPING = Dict{String, Tuple{Type, Type}}(
     "JuliaLang.Symbol" => (Symbol, String),
 )
 
-function extensiontype(meta)
+function extensiontype(f, meta)
     if haskey(meta, "ARROW:extension:name")
         typename = meta["ARROW:extension:name"]
         if haskey(ARROW_TO_JULIA_TYPE_MAPPING, typename)
-            return ARROW_TO_JULIA_TYPE_MAPPING[typename][1]
+            T = ARROW_TO_JULIA_TYPE_MAPPING[typename][1]
+            return f.nullable ? Union{T, Missing} : T
         else
             @warn "unsupported ARROW:extension:name type: \"$typename\""
         end

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -43,7 +43,7 @@ function juliaeltype(f::Meta.Field, meta::Dict{String, String}, convert::Bool)
     TT = juliaeltype(f, convert)
     !convert && return TT
     T = finaljuliatype(TT)
-    TTT = ArrowTypes.extensiontype(meta)
+    TTT = ArrowTypes.extensiontype(f, meta)
     return something(TTT, T)
 end
 


### PR DESCRIPTION
For custom extension types (currently automatically supported for `Char`
and `Symbol` types), we were failing to take into account whether the
field was nullable or not; this led to the case where a column might be
`['a', missing]`, but when deserializing, the column type was just
`Char` instead of `Union{Char, Missing}`. The fix is to enhance the
`ArrowTypes.extensiontype` function to also take the `field` argument
and check the nullability before returning.

Fixes #68