### PR TITLE
Finish support for automatic custom struct deserialization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+    tags: '*'
+jobs:
+  test:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'
+          - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        include:
+          - os: windows-latest
+            version: '1'
+            arch: x86
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: '1'
+      - run: |
+          julia --project=docs -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
+      - run: julia --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,13 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:
           - ubuntu-latest
         arch:
           - x64
-        include:
-          - os: windows-latest
-            version: '1'
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -69,7 +69,11 @@ function arrowvector(::Type{S}, x, i, nl, fi, de, ded, meta; kw...) where {S}
     if ArrowTypes.istyperegistered(S)
         meta = meta === nothing ? Dict{String, String}() : meta
         arrowtype = ArrowTypes.getarrowtype!(meta, S)
-        return arrowvector(converter(arrowtype, x), i, nl, fi, de, ded, meta; kw...)
+        if arrowtype === S
+            return arrowvector(ArrowType(S), x, i, nl, fi, de, ded, meta; kw...)
+        else
+            return arrowvector(converter(arrowtype, x), i, nl, fi, de, ded, meta; kw...)
+        end
     end
     return arrowvector(ArrowType(S), x, i, nl, fi, de, ded, meta; kw...)
 end

--- a/src/arraytypes/struct.jl
+++ b/src/arraytypes/struct.jl
@@ -81,6 +81,11 @@ function arrowvector(::StructType, x, i, nl, fi, de, ded, meta; kw...)
     len = length(x)
     validity = ValidityBitmap(x)
     T = Base.nonmissingtype(eltype(x))
+    if ArrowTypes.structtype(T) === ArrowTypes.STRUCT
+        meta = meta === nothing ? Dict{String, String}() : meta
+        ArrowTypes.registertype!(T, T)
+        ArrowTypes.getarrowtype!(meta, T)
+    end
     data = Tuple(arrowvector(ToStruct(x, j), i, nl + 1, j, de, ded, nothing; kw...) for j = 1:fieldcount(T))
     return Struct{eltype(x), typeof(data)}(validity, data, len, meta)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -109,7 +109,6 @@ struct Converter{T, A} <: AbstractVector{T}
     data::A
 end
 
-converter(::Type{T}, x::AbstractArray{T}) where {T} = x
 converter(::Type{T}, x::A) where {T, A} = Converter{eltype(A) >: Missing ? Union{T, Missing} : T, A}(x)
 converter(::Type{T}, x::ChainedVector{A}) where {T, A} = ChainedVector([converter(T, x) for x in x.arrays])
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -109,6 +109,7 @@ struct Converter{T, A} <: AbstractVector{T}
     data::A
 end
 
+converter(::Type{T}, x::AbstractArray{T}) where {T} = x
 converter(::Type{T}, x::A) where {T, A} = Converter{eltype(A) >: Missing ? Union{T, Missing} : T, A}(x)
 converter(::Type{T}, x::ChainedVector{A}) where {T, A} = ChainedVector([converter(T, x) for x in x.arrays])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,12 @@ using Test, Arrow, Tables, Dates, PooledArrays, TimeZones
 include(joinpath(dirname(pathof(Arrow)), "../test/testtables.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/integrationtest.jl"))
 
+struct CustomStruct
+    x::Int
+    y::Float64
+    z::String
+end
+
 @testset "Arrow" begin
 
 @testset "table roundtrips" begin
@@ -168,6 +174,15 @@ Arrow.write(io, t)
 seekstart(io)
 tt = Arrow.Table(io)
 @test isequal(tt.a, ['a', missing])
+
+# automatic custom struct serialization/deserialization
+t = (col1=[CustomStruct(1, 2.3, "hey"), CustomStruct(4, 5.6, "there")],)
+io = IOBuffer()
+Arrow.write(io, t)
+seekstart(io)
+tt = Arrow.Table(io)
+@test length(tt) == length(t)
+@test all(isequal.(values(t), values(tt)))
 
 end # @testset "misc"
 


### PR DESCRIPTION
As pointed out on a slack post, we were supporting automatic custom
struct _serialization_, but not deserialization; the custom structs were
just deserialized as `NamedTuple`s. In this PR, I propose using the
custom extension type machinery to ensure custom structs can be
deserialized. Currently this will all happend automatically for the
user, but I'd like to update the documentation around how users should
approach using arrow for custom types, because they _should_ get in the
habit of calling `ArrowTypes.registertype!` to ensure their serialized
custom struct can always be deserialized. For example, if a user
serializes and deserialized a custom struct in the same Julia session,
it will currently "just work", but if the custom struct column is
serialized in a session, then deserialized in a new session, where the
type hasn't been defined or registered, the column will be deserialized
as `NamedTuple`.