### PR TITLE
Fix Union type deserialization

### DIFF
--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -60,6 +60,7 @@ arrowconvert(::Type{Symbol}, x::String) = Symbol(x)
 arrowconvert(::Type{String}, x::Symbol) = String(x)
 
 ArrowType(::Type{<:AbstractArray}) = ListType()
+ArrowType(::Type{<:AbstractSet}) = ListType()
 
 struct FixedSizeListType <: ArrowType end
 

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -60,7 +60,6 @@ arrowconvert(::Type{Symbol}, x::String) = Symbol(x)
 arrowconvert(::Type{String}, x::Symbol) = String(x)
 
 ArrowType(::Type{<:AbstractArray}) = ListType()
-ArrowType(::Type{<:AbstractSet}) = ListType()
 
 struct FixedSizeListType <: ArrowType end
 

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -392,7 +392,7 @@ end
 
 # Unions
 function juliaeltype(f::Meta.Field, u::Meta.Union, convert)
-    return UnionT{u.mode, u.typeIds !== nothing ? Tuple(u.typeIds) : u.typeIds, Tuple{(juliaeltype(x, buildmetadata(x), convert) for x in f.children)...}}
+    return Union{(juliaeltype(x, buildmetadata(x), convert) for x in f.children)...}
 end
 
 arrowtype(b, x::Union{DenseUnion{TT, S}, SparseUnion{TT, S}}) where {TT, S} = arrowtype(b, TT, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -184,6 +184,15 @@ tt = Arrow.Table(io)
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
 
+# 76
+t = (col1=NamedTuple{(:a,),Tuple{Union{Int,String}}}[(a=1,), (a="x",)],)
+io = IOBuffer()
+Arrow.write(io, t)
+seekstart(io)
+tt = Arrow.Table(io)
+@test length(tt) == length(t)
+@test all(isequal.(values(t), values(tt)))
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes #76. I think this was just a relic of old code from early work on
the package, but `juliaeltype` is meant to return "julia" types, not
arrow types.