### PR TITLE
add `ArrowTypes.default` methods and tests for dates

### DIFF
--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -52,6 +52,12 @@ function arrowvector(x, i, nl, fi, de, ded, meta; dictencoding::Bool=false, dict
     return arrowvector(S, x, i, nl, fi, de, ded, meta; dictencode=dictencode, kw...)
 end
 
+# defaults for Dates types
+ArrowTypes.default(::Type{Dates.Date}) = Dates.Date(1,1,1)
+ArrowTypes.default(::Type{Dates.Time}) = Dates.Time(1,1,1)
+ArrowTypes.default(::Type{Dates.DateTime}) = Dates.DateTime(1,1,1,1,1,1)
+ArrowTypes.default(::Type{TimeZones.ZonedDateTime}) = TimeZones.ZonedDateTime(1,1,1,1,1,1,TimeZones.tz"UTC")
+
 # conversions to arrow types
 arrowvector(::Type{Dates.Date}, x, i, nl, fi, de, ded, meta; kw...) =
     arrowvector(converter(DATE, x), i, nl, fi, de, ded, meta; kw...)

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -1,0 +1,45 @@
+import Dates
+import TimeZones
+
+struct WrappedDate
+    x::Dates.Date
+end
+Arrow.ArrowTypes.registertype!(WrappedDate, WrappedDate)
+
+struct WrappedTime
+    x::Dates.Time
+end
+Arrow.ArrowTypes.registertype!(WrappedTime, WrappedTime)
+
+struct WrappedDateTime
+    x::Dates.DateTime
+end
+Arrow.ArrowTypes.registertype!(WrappedDateTime, WrappedDateTime)
+
+struct WrappedZonedDateTime
+    x::TimeZones.ZonedDateTime
+end
+Arrow.ArrowTypes.registertype!(WrappedZonedDateTime, WrappedZonedDateTime)
+
+
+@testset "Date and time wrappers with missing" begin
+    for T in (WrappedDate, WrappedTime, WrappedDateTime, WrappedZonedDateTime)
+        if T == WrappedZonedDateTime
+            time = T(Dates.now(TimeZones.tz"UTC"))
+        else
+            time = T(Dates.now())
+        end
+        table = (; x = [missing, missing, time, missing, time])
+        io = IOBuffer()
+        Arrow.write(io, table)
+        seekstart(io)
+        tbl = Arrow.Table(io)
+        @test isequal(collect(tbl.x), table.x)
+    end
+end
+
+@testset "`default(T) isa T`" begin
+    for T in (Dates.Date, Dates.Time, Dates.DateTime, TimeZones.ZonedDateTime, Dates.Nanosecond, Dates.Millisecond, Dates.Second, Dates.Day, Dates.Month, Dates.Year)
+        @test Arrow.ArrowTypes.default(T) isa T
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ using Test, Arrow, Tables, Dates, PooledArrays, TimeZones
 
 include(joinpath(dirname(pathof(Arrow)), "../test/testtables.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/integrationtest.jl"))
+include(joinpath(dirname(pathof(Arrow)), "../test/dates.jl"))
 
 struct CustomStruct
     x::Int


### PR DESCRIPTION
Fixes https://github.com/JuliaData/Arrow.jl/issues/84

The issue is that e.g. `zero(Date) == Day(0)` which is not a `Date`, so the `ArrowTypes.default` fallback gives the wrong type here. So I added fallbacks and tests.

I didn't really get how the tests are organized so I'm not sure I've added the tests in the right spot.