### PR TITLE
add default UUID <-> UInt128 Arrow type mapping

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ PooledArrays = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 SentinelArrays = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 CodecLz4 = "0.4"

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -20,6 +20,8 @@ in order to signal how they should be serialized in the arrow format.
 """
 module ArrowTypes
 
+using UUIDs
+
 export ArrowType, NullType, PrimitiveType, BoolType, ListType, FixedSizeListType, MapType, StructType, UnionType, DictEncodedType
 
 abstract type ArrowType end
@@ -41,6 +43,14 @@ struct PrimitiveType <: ArrowType end
 
 ArrowType(::Type{<:Integer}) = PrimitiveType()
 ArrowType(::Type{<:AbstractFloat}) = PrimitiveType()
+
+arrowconvert(::Type{UInt128}, u::UUID) = UInt128(u)
+arrowconvert(::Type{UUID}, u::UInt128) = UUID(u)
+
+# This method is included as a deprecation path to allow reading Arrow files that may have
+# been written before Arrow.jl defined its own UUID <-> UInt128 mapping (in which case
+# a struct-based fallback `JuliaLang.UUID` extension type may have been utilized)
+arrowconvert(::Type{UUID}, u::NamedTuple{(:value,),Tuple{UInt128}}) = UUID(u.value)
 
 struct BoolType <: ArrowType end
 ArrowType(::Type{Bool}) = BoolType()
@@ -115,6 +125,7 @@ default(::Type{NamedTuple{names, types}}) where {names, types} = NamedTuple{name
 const JULIA_TO_ARROW_TYPE_MAPPING = Dict{Type, Tuple{String, Type}}(
     Char => ("JuliaLang.Char", UInt32),
     Symbol => ("JuliaLang.Symbol", String),
+    UUID => ("JuliaLang.UUID", UInt128),
 )
 
 istyperegistered(::Type{T}) where {T} = haskey(JULIA_TO_ARROW_TYPE_MAPPING, T)
@@ -129,6 +140,7 @@ end
 const ARROW_TO_JULIA_TYPE_MAPPING = Dict{String, Tuple{Type, Type}}(
     "JuliaLang.Char" => (Char, UInt32),
     "JuliaLang.Symbol" => (Symbol, String),
+    "JuliaLang.UUID" => (UUID, UInt128),
 )
 
 function extensiontype(f, meta)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-using Test, Arrow, Tables, Dates, PooledArrays, TimeZones
+using Test, Arrow, Tables, Dates, PooledArrays, TimeZones, UUIDs
 
 include(joinpath(dirname(pathof(Arrow)), "../test/testtables.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/integrationtest.jl"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,10 @@ tt = Arrow.Table(io)
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
 
+# 89 - test deprecation path for old UUID autoconversion
+u = 0x6036fcbd20664bd8a65cdfa25434513f
+@test Arrow.ArrowTypes.arrowconvert(UUID, (value=u,)) === UUID(u)
+
 end # @testset "misc"
 
 end

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -144,7 +144,8 @@ testtables = [
     (
       col1=[:hey, :there, :sailor],
       col2=['a', 'b', 'c'],
-      col3=Arrow.DictEncode(['a', 'a', 'b'])
+      col3=Arrow.DictEncode(['a', 'a', 'b']),
+      col4=[UUID("48075322-8645-4ac6-b590-c9f46068565a"), UUID("99c7d976-ccfd-45b9-9793-51008607c638"), UUID("f96d9974-5a7b-47e3-bbc0-d680d11490d4")]
     ),
     NamedTuple(),
     NamedTuple(),


### PR DESCRIPTION
(vaguely related: https://issues.apache.org/jira/browse/ARROW-2051)

Naively this seems like a more reasonable Julia-agnostic default than the fallback that `UUID` currently hits (an example of which can be found in #88). My use case is that I'm spec'ing out a Julia-agnostic, Arrow-based format and I'm specifying that "UUID columns are stored as 128-bit binary values" - which seems reasonable but technically conflicts with Arrow.jl's current `UUID` fallback.

If this isn't a good idea to include by default here, I can put these definitions in my downstream package - just seemed like a good idea to upstream it if possible to avoid potential conflicts w/ other downstream packages that might rely on the existing default behavior

@quinnj if you're good with this idea, I can add tests + take out of draft mode.