### PR TITLE
Fix `deploydocs`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,4 +20,5 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/JuliaData/Arrow.jl",
+    devbranch = "main"
 )


### PR DESCRIPTION
I went to see if my warning from #96 was formatted correctly, and realized the docs didn't deploy properly. From https://github.com/JuliaData/Arrow.jl/runs/1648115163#step:5:66, I think this should fix them.

It would probably be good to get this in before #94, so 1.1 has new stable docs.