### PR TITLE
Fix copy on DictEncoding arrays with missing values

### DIFF
--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -203,16 +203,9 @@ function Base.copy(x::DictEncoded{T, S}) where {T, S}
     pool = copy(x.encoding.data)
     valid = x.validity
     inds = x.indices
-    if T >: Missing
-        refs = Vector{S}(undef, length(inds))
-        @inbounds for i = 1:length(inds)
-            refs[i] = ifelse(valid[i], inds[i] + one(S), missing)
-        end
-    else
-        refs = copy(inds)
-        @inbounds for i = 1:length(inds)
-            refs[i] = refs[i] + one(S)
-        end
+    refs = copy(inds)
+    @inbounds for i = 1:length(inds)
+        refs[i] = refs[i] + one(S)
     end
     return PooledArray(PooledArrays.RefArray(refs), Dict{T, S}(val => i for (i, val) in enumerate(pool)), pool)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -208,6 +208,11 @@ tt = Arrow.Table(io)
 @test copy(tt.b) isa Vector{UUID}
 @test copy(tt.c) isa Vector{Union{Missing,Nanosecond}}
 
+# copy on DictEncoding w/ missing values
+x = PooledArray(["hey", missing])
+x2 = Arrow.toarrowvector(x)
+@test isequal(copy(x2), x)
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
The copy code for DictEncoding erroneously tried to special-case
`missing` when copying, which is unnecessary since `missing` is just
treated like any other regular ref value. By removing the special-cased
branch of code, we avoid treating it differently and the code copies the
`DictEncoding` array as a `PooledArray` as expected.