### PR TITLE
change UUID <-> Arrow mapping to (de)serialize to/from 16-byte FixedSizeBinary

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -53,9 +53,11 @@ Apart from letting other packages have all the fun, an `Arrow.Table` itself can 
 
 In the arrow data format, specific logical types are supported, a list of which can be found [here](https://arrow.apache.org/docs/status.html#data-types). These include booleans, integers of various bit widths, floats, decimals, time types, and binary/string. While most of these map naturally to types builtin to Julia itself, there are a few cases where the definitions are slightly different, and in these cases, by default, they are converted to more "friendly" Julia types (this auto conversion can be avoided by passing `convert=false` to `Arrow.Table`, like `Arrow.Table(file; convert=false)`). Examples of arrow to julia type mappings include:
 
-* `Date`, `Time`, `Timestamp`, and `Duration` all have natural Julia defintions in `Dates.Date`, `Dates.Time`, `TimeZones.ZonedDateTime`, and `Dates.Period` subtypes, respectively. 
+* `Date`, `Time`, `Timestamp`, and `Duration` all have natural Julia defintions in `Dates.Date`, `Dates.Time`, `TimeZones.ZonedDateTime`, and `Dates.Period` subtypes, respectively.
 * `Char` and `Symbol` Julia types are mapped to arrow string types, with additional metadata of the original Julia type; this allows deserializing directly to `Char` and `Symbol` in Julia, while other language implementations will see these columns as just strings
+* Similarly to the above, the `UUID` Julia type is mapped to a 128-bit `FixedSizeBinary` arrow type.
 * `Decimal128` and `Decimal256` have no corresponding builtin Julia types, so they're deserialized using a compatible type definition in Arrow.jl itself: `Arrow.Decimal`
+
 
 Note that when `convert=false` is passed, data will be returned in Arrow.jl-defined types that exactly match the arrow definitions of those types; the authoritative source for how each type represents its data can be found in the arrow [`Schema.fbs`](https://github.com/apache/arrow/blob/master/format/Schema.fbs) file.
 
@@ -118,7 +120,7 @@ With `Arrow.write`, you provide either an `io::IO` argument or `file::String` to
 What are some examples of Tables.jl-compatible sources? A few examples include:
 * `Arrow.write(io, df::DataFrame)`: A `DataFrame` is a collection of indexable columns
 * `Arrow.write(io, CSV.File(file))`: read data from a csv file and write out to arrow format
-* `Arrow.write(io, DBInterface.execute(db, sql_query))`: Execute an SQL query against a database via the [`DBInterface.jl`](https://github.com/JuliaDatabases/DBInterface.jl) interface, and write the query resultset out directly in the arrow format. Packages that implement DBInterface include [SQLite.jl](https://juliadatabases.github.io/SQLite.jl/stable/), [MySQL.jl](https://juliadatabases.github.io/MySQL.jl/dev/), and [ODBC.jl](http://juliadatabases.github.io/ODBC.jl/latest/). 
+* `Arrow.write(io, DBInterface.execute(db, sql_query))`: Execute an SQL query against a database via the [`DBInterface.jl`](https://github.com/JuliaDatabases/DBInterface.jl) interface, and write the query resultset out directly in the arrow format. Packages that implement DBInterface include [SQLite.jl](https://juliadatabases.github.io/SQLite.jl/stable/), [MySQL.jl](https://juliadatabases.github.io/MySQL.jl/dev/), and [ODBC.jl](http://juliadatabases.github.io/ODBC.jl/latest/).
 * `df |> @map(...) |> Arrow.write(io)`: Write the results of a [Query.jl](https://www.queryverse.org/Query.jl/stable/) chain of operations directly out as arrow data
 * `jsontable(json) |> Arrow.write(io)`: Treat a json array of objects or object of arrays as a "table" and write it out as arrow data using the [JSONTables.jl](https://github.com/JuliaData/JSONTables.jl) package
 * `Arrow.write(io, (col1=data1, col2=data2, ...))`: a `NamedTuple` of `AbstractVector`s or an `AbstractVector` of `NamedTuple`s are both considered tables by default, so they can be quickly constructed for easy writing of arrow data if you already have columns of data

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -44,15 +44,6 @@ struct PrimitiveType <: ArrowType end
 ArrowType(::Type{<:Integer}) = PrimitiveType()
 ArrowType(::Type{<:AbstractFloat}) = PrimitiveType()
 
-arrowconvert(::Type{NTuple{16,UInt8}}, u::UUID) = reinterpret(NTuple{16,UInt8}, [u])[]
-arrowconvert(::Type{UUID}, u::NTuple{16,UInt8}) = UUID(reinterpret(UInt128, [u])[])
-
-# These methods are included as deprecation paths to allow reading Arrow files that may have
-# been written before Arrow.jl's current UUID <-> NTuple{16,UInt8} mapping existed (in which case
-# a struct-based fallback `JuliaLang.UUID` extension type may have been utilized)
-arrowconvert(::Type{UUID}, u::NamedTuple{(:value,),Tuple{UInt128}}) = UUID(u.value)
-arrowconvert(::Type{UUID}, u::UInt128) = UUID(u)
-
 struct BoolType <: ArrowType end
 ArrowType(::Type{Bool}) = BoolType()
 
@@ -77,6 +68,19 @@ struct FixedSizeListType <: ArrowType end
 ArrowType(::Type{NTuple{N, T}}) where {N, T} = FixedSizeListType()
 gettype(::Type{NTuple{N, T}}) where {N, T} = T
 getsize(::Type{NTuple{N, T}}) where {N, T} = N
+
+ArrowType(::Type{UUID}) = FixedSizeListType()
+gettype(::Type{UUID}) = UInt8
+getsize(::Type{UUID}) = 16
+
+arrowconvert(::Type{NTuple{16,UInt8}}, u::UUID) = reinterpret(NTuple{16,UInt8}, [u])[]
+arrowconvert(::Type{UUID}, u::NTuple{16,UInt8}) = UUID(reinterpret(UInt128, [u])[])
+
+# These methods are included as deprecation paths to allow reading Arrow files that may have
+# been written before Arrow.jl's current UUID <-> NTuple{16,UInt8} mapping existed (in which case
+# a struct-based fallback `JuliaLang.UUID` extension type may have been utilized)
+arrowconvert(::Type{UUID}, u::NamedTuple{(:value,),Tuple{UInt128}}) = UUID(u.value)
+arrowconvert(::Type{UUID}, u::UInt128) = UUID(u)
 
 struct StructType <: ArrowType end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -197,6 +197,7 @@ tt = Arrow.Table(io)
 # 89 - test deprecation path for old UUID autoconversion
 u = 0x6036fcbd20664bd8a65cdfa25434513f
 @test Arrow.ArrowTypes.arrowconvert(UUID, (value=u,)) === UUID(u)
+@test Arrow.ArrowTypes.arrowconvert(UUID, u) === UUID(u)
 
 # 98
 t = (a = [Nanosecond(0), Nanosecond(1)], b = [uuid4(), uuid4()], c = [missing, Nanosecond(1)])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,10 +194,12 @@ tt = Arrow.Table(io)
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
 
-# 89 - test deprecation path for old UUID autoconversion
+# 89 etc. - test deprecation paths for old UUID autoconversion + UUID FixedSizeListType overloads
 u = 0x6036fcbd20664bd8a65cdfa25434513f
 @test Arrow.ArrowTypes.arrowconvert(UUID, (value=u,)) === UUID(u)
 @test Arrow.ArrowTypes.arrowconvert(UUID, u) === UUID(u)
+@test Arrow.ArrowTypes.gettype(UUID) == UInt8
+@test Arrow.ArrowTypes.getsize(UUID) == 16
 
 # 98
 t = (a = [Nanosecond(0), Nanosecond(1)], b = [uuid4(), uuid4()], c = [missing, Nanosecond(1)])


### PR DESCRIPTION
...to make tables written out by Arrow.jl more portable. 

I'm dumb and didn't realize e.g. `pyarrow` doesn't support 128-bit ints, so currently UUID-containing tables will fail to be read by e.g. `pa.feather.read_feather(...)`.

There's even pyarrow documentation that [suggests to Python users that UUIDs can be written as FixedSizeBinary columns](https://arrow.apache.org/docs/python/extending_types.html), so this seems like a more friendly/correct way to do this.