### PR TITLE
add isbitstype optimized path for FixedSizeList getindex

### DIFF
--- a/src/arraytypes/fixedsizelist.jl
+++ b/src/arraytypes/fixedsizelist.jl
@@ -50,18 +50,8 @@ end
 function _unsafe_load_tuple(::Type{NTuple{N,T}}, bytes::Vector{UInt8}, i::Integer) where {N,T}
     x = Ref(bytes, i)
     y = Ref{NTuple{N,T}}()
-    _unsafe_cast!(y, x, N)
+    ArrowTypes._unsafe_cast!(y, x, N)
     return y[]
-end
-
-function _unsafe_cast!(y::Ref{Y}, x::Ref, n::Integer) where {Y}
-    X = eltype(x)
-    GC.@preserve x y begin
-        ptr_x = Base.unsafe_convert(Ptr{X}, x)
-        ptr_y = Base.unsafe_convert(Ptr{Y}, y)
-        unsafe_copyto!(Ptr{X}(ptr_y), ptr_x, n)
-    end
-    return y
 end
 
 @propagate_inbounds function Base.setindex!(l::FixedSizeList{T}, v::T, i::Integer) where {T}


### PR DESCRIPTION
ref https://github.com/JuliaData/Arrow.jl/pull/103#issuecomment-757354386

#103 before this PR:

```
julia> @time copy(uuids_fixed);
  0.142450 seconds (1.06 M allocations: 74.713 MiB, 2.43% gc time)
```

#103 after this PR:

```
julia> @time copy(y.recording_uuid);
  0.016563 seconds (2 allocations: 3.248 MiB)
```

Order of magnitude improvement + allocations/memory now on par with pre-#103 behavior. Nice!

Still an order of magnitude of runtime perf on the table compared to the equivalent `Primitive` though. will play around and check whether branching changes/direct pointer manipulation might recover some of that.