### PR TITLE
Fix copy on DictEncode

### DIFF
--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -59,6 +59,7 @@ Base.size(x::DictEncode) = (length(x.data),)
 Base.iterate(x::DictEncode, st...) = iterate(x.data, st...)
 Base.getindex(x::DictEncode, i::Int) = getindex(x.data, i)
 ArrowTypes.ArrowType(::Type{<:DictEncodeType}) = DictEncodedType()
+Base.copy(x::DictEncode) = DictEncode(x.data, x.id)
 
 """
     Arrow.DictEncoded


### PR DESCRIPTION
Fixes #102. The issue comes up because DataFrames constructor tries to
make a copy of input columns by default when constructing; for
DictEncode, it's just a wrapper to signal that a column should be
copied, so we just make a shallow copy.