### PR TITLE
Make compressed writing threadsafe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 Manifest.toml
+.DS_STORE
 *.jl.cov
 *.jl.*.cov
 *.jl.mem

--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -30,14 +30,18 @@ validitybitmap(x::ArrowVector) = x.validity
 nullcount(x::ArrowVector) = validitybitmap(x).nc
 getmetadata(x::ArrowVector) = x.metadata
 
-function toarrowvector(x, i=1, de=Dict{Int64, Any}(), ded=DictEncoding[], meta=getmetadata(x); compression::Union{Nothing, LZ4FrameCompressor, ZstdCompressor}=nothing, kw...)
+function toarrowvector(x, i=1, de=Dict{Int64, Any}(), ded=DictEncoding[], meta=getmetadata(x); compression::Union{Nothing, Vector{LZ4FrameCompressor}, LZ4FrameCompressor, Vector{ZstdCompressor}, ZstdCompressor}=nothing, kw...)
     @debug 2 "converting top-level column to arrow format: col = $(typeof(x)), compression = $compression, kw = $(kw.data)"
     @debug 3 x
     A = arrowvector(x, i, 0, 0, de, ded, meta; compression=compression, kw...)
     if compression isa LZ4FrameCompressor
         A = compress(Meta.CompressionType.LZ4_FRAME, compression, A)
+    elseif compression isa Vector{LZ4FrameCompressor}
+        A = compress(Meta.CompressionType.LZ4_FRAME, compression[Threads.threadid()], A)
     elseif compression isa ZstdCompressor
         A = compress(Meta.CompressionType.ZSTD, compression, A)
+    elseif compression isa Vector{ZstdCompressor}
+        A = compress(Meta.CompressionType.ZSTD, compression[Threads.threadid()], A)
     end
     @debug 2 "converted top-level column to arrow format: $(typeof(A))"
     @debug 3 A

--- a/src/write.jl
+++ b/src/write.jl
@@ -85,9 +85,9 @@ end
 
 function write(io, source, writetofile, largelists, compress, denseunions, dictencode, dictencodenested, alignment)
     if compress === :lz4
-        compress = LZ4_FRAME_COMPRESSOR[]
+        compress = LZ4_FRAME_COMPRESSOR
     elseif compress === :zstd
-        compress = ZSTD_COMPRESSOR[]
+        compress = ZSTD_COMPRESSOR
     elseif compress isa Symbol
         throw(ArgumentError("unsupported compress keyword argument value: $compress. Valid values include `:lz4` or `:zstd`"))
     end


### PR DESCRIPTION
Fixes #82. The problem when trying to write arrow using multiple threads and compression was there was only a single compressor object that each thread was simultaneously trying to use. This PR ensures there is a compressor object per thread that will be used per thread.

@kescobo, will you try the code you have causing #108? With this PR, I can't seem to reproduce any hanging when writing. If you can still reproduce, I'd like to dig in further with your setup and try to figure out why it's hanging.