### PR TITLE
fix accidental invocation of _unsafe_load_tuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.2.3"
+version = "1.2.4"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"

--- a/src/arraytypes/fixedsizelist.jl
+++ b/src/arraytypes/fixedsizelist.jl
@@ -38,7 +38,7 @@ Base.size(l::FixedSizeList) = (l.ℓ,)
         return missing
     else
         off = (i - 1) * N
-        if X === T && isbitstype(Y)
+        if X === T && isbitstype(Y) && l.data isa Vector{UInt8}
             tup = _unsafe_load_tuple(NTuple{N,Y}, l.data, off + 1)
         else
             tup = ntuple(j->l.data[off + j], N)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -236,11 +236,18 @@ av = Arrow.toarrowvector(CategoricalArray(["a", "bb", "ccc"]))
 @test eltype(av) == String
 
 # 121
-
 a = PooledArray(repeat(string.('S', 1:130), inner=5), compress=true)
 @test eltype(a.refs) == UInt8
 av = Arrow.toarrowvector(a)
 @test eltype(av.indices) == Int16
+
+# 123
+t = (x = collect(zip(rand(10), rand(10))),)
+io = IOBuffer()
+Arrow.write(io, t)
+seekstart(io)
+t2 = Arrow.Table(io)
+@test t2.x == t.x
 
 end # @testset "misc"
 


### PR DESCRIPTION
This optimization was only meant to be used when the underlying data buffer was straight bytes. Looking at this, it might actually also be refactorable to be suitable in the more general case when `l.data isa Vector{D} && isbitstype(D)`, but AFAICT seems like that case wouldn't arise in practice that often (unless I'm mistaken).

Bumped the Project.toml to facilitate tagging after merging.