### PR TITLE
Prevent bare CategoricalArrays from being converted to arrow vectors

### DIFF
--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -33,7 +33,7 @@ getmetadata(x::ArrowVector) = x.metadata
 function toarrowvector(x, i=1, de=Dict{Int64, Any}(), ded=DictEncoding[], meta=getmetadata(x); compression::Union{Nothing, Vector{LZ4FrameCompressor}, LZ4FrameCompressor, Vector{ZstdCompressor}, ZstdCompressor}=nothing, kw...)
     @debug 2 "converting top-level column to arrow format: col = $(typeof(x)), compression = $compression, kw = $(kw.data)"
     @debug 3 x
-    if eltype(x).name.name === :CategoricalPool
+    if eltype(x) isa DataType && eltype(x).name.name === :CategoricalPool
         error("CategoricalPool is a recursive data structure and not allowed for serializing; ensure data (`tbl`) passed to `Arrow.write(_, tbl)` is a valid Tables.jl table")
     end
     A = arrowvector(x, i, 0, 0, de, ded, meta; compression=compression, kw...)

--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -33,6 +33,9 @@ getmetadata(x::ArrowVector) = x.metadata
 function toarrowvector(x, i=1, de=Dict{Int64, Any}(), ded=DictEncoding[], meta=getmetadata(x); compression::Union{Nothing, Vector{LZ4FrameCompressor}, LZ4FrameCompressor, Vector{ZstdCompressor}, ZstdCompressor}=nothing, kw...)
     @debug 2 "converting top-level column to arrow format: col = $(typeof(x)), compression = $compression, kw = $(kw.data)"
     @debug 3 x
+    if eltype(x).name.name === :CategoricalPool
+        error("CategoricalPool is a recursive data structure and not allowed for serializing; ensure data (`tbl`) passed to `Arrow.write(_, tbl)` is a valid Tables.jl table")
+    end
     A = arrowvector(x, i, 0, 0, de, ded, meta; compression=compression, kw...)
     if compression isa LZ4FrameCompressor
         A = compress(Meta.CompressionType.LZ4_FRAME, compression, A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -252,6 +252,9 @@ seekstart(io)
 t2 = Arrow.Table(io)
 @test t2.x == t.x
 
+# 143
+@test_throws ErrorException Arrow.write(IOBuffer(), CategoricalArray([1,2,3]))
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes #143. This has now come up a couple of times to people, even if
just by accident, but it's really jarring to have your session hang. We
could perhaps eventually do a more sophisticated cycle detection to
always prevent this, but this is a pretty easy bandaid for now.