### PR TITLE
Ensure serializing Arrow.DictEncoded writes dictionary messages

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -189,12 +189,12 @@ function Base.close(ch::OrderedChannel)
     return
 end
 
-struct Lockable{T}
-    x::T
+mutable struct Lockable
+    x
     lock::ReentrantLock
 end
 
-Lockable(x::T) where {T} = Lockable{T}(x, ReentrantLock())
+Lockable(x) = Lockable(x, ReentrantLock())
 
 Base.lock(x::Lockable) = lock(x.lock)
 Base.unlock(x::Lockable) = unlock(x.lock)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -260,6 +260,30 @@ seekstart(io)
 tt = Arrow.Table(io)
 @test length(tt.a) == 132
 
+# 126
+t = Tables.partitioner(
+    (
+        (a=Arrow.toarrowvector(PooledArray([1,2,3  ])),),
+        (a=Arrow.toarrowvector(PooledArray([1,2,3,4])),),
+        (a=Arrow.toarrowvector(PooledArray([1,2,3,4,5])),),
+    )
+)
+io = IOBuffer()
+Arrow.write(io, t)
+seekstart(io)
+tt = Arrow.Table(io)
+@test length(tt.a) == 12
+@test tt.a == [1, 2, 3, 1, 2, 3, 4, 1, 2, 3, 4, 5]
+
+t = Tables.partitioner(
+    (
+        (a=Arrow.toarrowvector(PooledArray([1,2,3  ], signed=true, compress=true)),),
+        (a=Arrow.toarrowvector(PooledArray(collect(1:129))),),
+    )
+)
+io = IOBuffer()
+@test_throws CompositeException Arrow.write(io, t)
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes #126. The issue here was when `Arrow.write` was faced with the
task of serializing an `Arrow.DictEncoded`. For most arrow array types,
if the input array is already an arrow array type, it's a no-op (e.g. if
you're writing out an `Arrow.Table`). The problem comes from
`Arrow.DictEncoded`, where there is still no conversion required, but we
do need to make a note of the dict encoded column to ensure a dictionary
message is written before the record batch. In addition, we also add
some code for handling delta dictionary messages if required from
multiple record batches that contain `Arrow.DictEncoded`s, which is a
valid use-case where you may have multiple arrow files, with the same
schema, that you wish to serialize as a single arrow file w/ each file
as a separate record batch.

Slightly unrelated, but there's also a fix here in our use of Lockable.
We actually had a race condition I ran into once where the locking was
on the Lockable object, but inside the locked region, we replaced the
entire Lockable instead of the _contents_ of the Lockable. This meant
anyone who started waiting on the Lockable's lock didn't see updates
when unlocked because the entire Lockable had been updated.