### PR TITLE
Better handle errors when something goes wrong writing partitions

### DIFF
--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -133,7 +133,6 @@ function arrowvector(::DictEncodedType, x::DictEncoded, i, nl, fi, de, ded, meta
             # in this case, we just need to check if any values in our local pool need to be delta dicationary serialized
             deltas = setdiff(x.encoding, encoding)
             if !isempty(deltas)
-                @show deltas
                 ET = indextype(encoding)
                 if length(deltas) + length(encoding) > typemax(ET)
                     error("fatal error serializing dict encoded column with ref index type of $ET; subsequent record batch unique values resulted in $(length(deltas) + length(encoding)) unique values, which exceeds possible index values in $ET")

--- a/src/write.jl
+++ b/src/write.jl
@@ -146,6 +146,10 @@ function write(io, source, writetofile, largelists, compress, denseunions, dicte
             end
         end
     end
+    if anyerror[]
+        @error "error writing arrow data on partition = $(errorref[][3])" exception=(errorref[][1], errorref[][2])
+        error("fatal error writing arrow data")
+    end
     # close our message-writing channel, no further put!-ing is allowed
     close(msgs)
     # now wait for our message-writing task to finish writing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,7 +238,7 @@ t = Tables.partitioner(
     )
 )
 io = IOBuffer()
-@test_throws CompositeException Arrow.write(io, t)
+@test_throws ErrorException Arrow.write(io, t)
 
 end # @testset "misc"
 


### PR DESCRIPTION
Follow up to #108. There were actually a few different issues all coming
together in @kjanosz's comment. The first being that `ZipFile.Reader`
doesn't like non-main threads touching its files _at all_. The Arrow.jl
problem there is when processing non-first partitions, we were just
`Threads.@spawn`-ing a task which then went off and sometimes became the
proverbial unheard tree falling in the forest. Like really, no one heard
these tasks and their poor exceptions.

The solution there is to be better shepherds of our spawned tasks; we
introduce a `anyerror` atomic bool that threads can set if they run into
issues and then in the main partition handling loop we'll check that. If
a thread ran into something, we'll log out the thread-specific
exception, then throw a generic writing error. This prevents the
"hanging" behavior people were seeing because the felled threads were
actually causing later tasks to hang on `put!`-ing into the
OrderedChannel.

After addressing this, we have the multithreaded ZipFile issue. With the
new `ntasks` keyword, it seems to make sense to me that if you pass
`ntasks=1`, you're really saying, I don't want any concurrency. So
anywhere we were `Threads.@spawn`ing, we now check if `ntasks == 1` and
if so, do an `@async` instead.