### PR TITLE
Overhaul type serialization/deserialization machinery

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -45,6 +45,8 @@ using Mmap
 import Dates
 using DataAPI, Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd, TimeZones, BitIntegers
 
+export ArrowTypes
+
 using Base: @propagate_inbounds
 import Base: ==
 

--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -57,17 +57,34 @@ function arrowvector(x, i, nl, fi, de, ded, meta; dictencoding::Bool=false, dict
     elseif x isa DictEncoded
         return arrowvector(DictEncodeType, x, i, nl, fi, de, ded, meta; dictencode=dictencode, kw...)    
     end
+    T = eltype(x)
     x = ToArrow(x)
     S = maybemissing(eltype(x))
+    if ArrowTypes.hasarrowname(T)
+        meta = meta === nothing ? Dict{String, String}() : meta
+        meta["ARROW:extension:name"] = String(ArrowTypes.arrowname(T))
+        meta["ARROW:extension:metadata"] = ""
+    end
     return arrowvector(S, x, i, nl, fi, de, ded, meta; dictencode=dictencode, kw...)
 end
 
-# fallback that calls ArrowKind
+# now we check for ArrowType converions and dispatch on ArrowKind
 function arrowvector(::Type{S}, x, i, nl, fi, de, ded, meta; kw...) where {S}
+    # deprecated and will be removed
+    if ArrowTypes.istyperegistered(S)
+        meta = meta === nothing ? Dict{String, String}() : meta
+        arrowtype = ArrowTypes.getarrowtype!(meta, S)
+        if arrowtype === S
+            return arrowvector(ArrowKind(S), x, i, nl, fi, de, ded, meta; kw...)
+        else
+            return arrowvector(converter(arrowtype, x), i, nl, fi, de, ded, meta; kw...)
+        end
+    end
+    # end deprecation
     return arrowvector(ArrowKind(S), x, i, nl, fi, de, ded, meta; kw...)
 end
 
-arrowvector(::NullType, x, i, nl, fi, de, ded, meta; kw...) = MissingVector(length(x))
+arrowvector(::NullKind, x, i, nl, fi, de, ded, meta; kw...) = MissingVector(length(x))
 compress(Z::Meta.CompressionType, comp, v::MissingVector) =
     Compressed{Z, MissingVector}(v, CompressedBuffer[], length(v), length(v), Compressed[])
 

--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -52,13 +52,14 @@ function arrowvector(x, i, nl, fi, de, ded, meta; dictencoding::Bool=false, dict
     if nl > maxdepth
         error("reached nested serialization level ($nl) deeper than provided max depth argument ($(maxdepth)); to increase allowed nesting level, pass `maxdepth=X`")
     end
+    T = maybemissing(eltype(x))
     if !(x isa DictEncode) && !dictencoding && (dictencode || DataAPI.refarray(x) !== x)
         x = DictEncode(x, dictencodeid(i, nl, fi))
     elseif x isa DictEncoded
         return arrowvector(DictEncodeType, x, i, nl, fi, de, ded, meta; dictencode=dictencode, kw...)    
+    elseif !(x isa DictEncode)
+        x = ToArrow(x)
     end
-    T = eltype(x)
-    x = ToArrow(x)
     S = maybemissing(eltype(x))
     if ArrowTypes.hasarrowname(T)
         meta = meta === nothing ? Dict{String, String}() : meta

--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -64,7 +64,7 @@ function arrowvector(x, i, nl, fi, de, ded, meta; dictencoding::Bool=false, dict
     if ArrowTypes.hasarrowname(T)
         meta = meta === nothing ? Dict{String, String}() : meta
         meta["ARROW:extension:name"] = String(ArrowTypes.arrowname(T))
-        meta["ARROW:extension:metadata"] = ""
+        meta["ARROW:extension:metadata"] = String(ArrowTypes.arrowmetadata(T))
     end
     return arrowvector(S, x, i, nl, fi, de, ded, meta; dictencode=dictencode, kw...)
 end

--- a/src/arraytypes/bool.jl
+++ b/src/arraytypes/bool.jl
@@ -38,7 +38,7 @@ Base.size(p::BoolVector) = (p.ℓ,)
     a, b = fldmod1(i, 8)
     @inbounds byte = p.arrow[p.pos + a - 1]
     # check individual bit of byte
-    return getbit(byte, b)
+    return ArrowTypes.fromarrow(T, getbit(byte, b))
 end
 
 @propagate_inbounds function Base.setindex!(p::BoolVector, v, i::Integer)
@@ -50,9 +50,9 @@ end
     return v
 end
 
-arrowvector(::BoolType, x::BoolVector, i, nl, fi, de, ded, meta; kw...) = x
+arrowvector(::BoolKind, x::BoolVector, i, nl, fi, de, ded, meta; kw...) = x
 
-function arrowvector(::BoolType, x, i, nl, fi, de, ded, meta; kw...)
+function arrowvector(::BoolKind, x, i, nl, fi, de, ded, meta; kw...)
     validity = ValidityBitmap(x)
     len = length(x)
     blen = cld(len, 8)

--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -71,7 +71,7 @@ Base.IndexStyle(::Type{<:DictEncode}) = Base.IndexLinear()
 Base.size(x::DictEncode) = (length(x.data),)
 Base.iterate(x::DictEncode, st...) = iterate(x.data, st...)
 Base.getindex(x::DictEncode, i::Int) = getindex(x.data, i)
-ArrowTypes.ArrowKind(::Type{<:DictEncodeType}) = DictEncodedType()
+ArrowTypes.ArrowKind(::Type{<:DictEncodeType}) = DictEncodedKind()
 Base.copy(x::DictEncode) = DictEncode(x.data, x.id)
 
 """
@@ -122,7 +122,7 @@ dictencodeid(colidx, nestedlevel, fieldid) = (Int64(nestedlevel) << 48) | (Int64
 getid(d::DictEncoded) = d.encoding.id
 getid(c::Compressed{Z, A}) where {Z, A <: DictEncoded} = c.data.encoding.id
 
-function arrowvector(::DictEncodedType, x::DictEncoded, i, nl, fi, de, ded, meta; dictencode::Bool=false, dictencodenested::Bool=false, kw...)
+function arrowvector(::DictEncodedKind, x::DictEncoded, i, nl, fi, de, ded, meta; dictencode::Bool=false, dictencodenested::Bool=false, kw...)
     id = x.encoding.id
     if !haskey(de, id)
         de[id] = Lockable(x.encoding)
@@ -152,7 +152,7 @@ function arrowvector(::DictEncodedType, x::DictEncoded, i, nl, fi, de, ded, meta
     return x
 end
 
-function arrowvector(::DictEncodedType, x, i, nl, fi, de, ded, meta; dictencode::Bool=false, dictencodenested::Bool=false, kw...)
+function arrowvector(::DictEncodedKind, x, i, nl, fi, de, ded, meta; dictencode::Bool=false, dictencodenested::Bool=false, kw...)
     @assert x isa DictEncode
     id = x.id == -1 ? dictencodeid(i, nl, fi) : x.id
     x = x.data

--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -71,7 +71,7 @@ Base.IndexStyle(::Type{<:DictEncode}) = Base.IndexLinear()
 Base.size(x::DictEncode) = (length(x.data),)
 Base.iterate(x::DictEncode, st...) = iterate(x.data, st...)
 Base.getindex(x::DictEncode, i::Int) = getindex(x.data, i)
-ArrowTypes.ArrowType(::Type{<:DictEncodeType}) = DictEncodedType()
+ArrowTypes.ArrowKind(::Type{<:DictEncodeType}) = DictEncodedType()
 Base.copy(x::DictEncode) = DictEncode(x.data, x.id)
 
 """

--- a/src/arraytypes/fixedsizelist.jl
+++ b/src/arraytypes/fixedsizelist.jl
@@ -32,7 +32,7 @@ Base.size(l::FixedSizeList) = (l.ℓ,)
 @propagate_inbounds function Base.getindex(l::FixedSizeList{T}, i::Integer) where {T}
     @boundscheck checkbounds(l, i)
     S = Base.nonmissingtype(T)
-    X = ArrowTypes.ArrowKind(S)
+    X = ArrowTypes.ArrowKind(ArrowTypes.ArrowType(S))
     N = ArrowTypes.getsize(X)
     Y = ArrowTypes.gettype(X)
     if X !== T && !(l.validity[i])
@@ -60,7 +60,7 @@ end
     if v === missing
         @inbounds l.validity[i] = false
     else
-        N = ArrowTypes.getsize(ArrowTypes.ArrowKind(Base.nonmissingtype(T)))
+        N = ArrowTypes.getsize(ArrowTypes.ArrowKind(ArrowTypes.ArrowType(Base.nonmissingtype(T))))
         off = (i - 1) * N
         foreach(1:N) do j
             @inbounds l.data[off + j] = v[j]
@@ -142,7 +142,7 @@ function makenodesbuffers!(col::FixedSizeList{T, A}, fieldnodes, fieldbuffers, b
     @debug 1 "made field buffer: bufferidx = $(length(fieldbuffers)), offset = $(fieldbuffers[end].offset), len = $(fieldbuffers[end].length), padded = $(padding(fieldbuffers[end].length, alignment))"
     bufferoffset += blen
     if eltype(A) === UInt8
-        blen = ArrowTypes.getsize(Base.nonmissingtype(T)) * len
+        blen = ArrowTypes.getsize(ArrowTypes.ArrowKind(Base.nonmissingtype(T))) * len
         push!(fieldbuffers, Buffer(bufferoffset, blen))
         @debug 1 "made field buffer: bufferidx = $(length(fieldbuffers)), offset = $(fieldbuffers[end].offset), len = $(fieldbuffers[end].length), padded = $(padding(fieldbuffers[end].length, alignment))"
         bufferoffset += padding(blen, alignment)

--- a/src/arraytypes/list.jl
+++ b/src/arraytypes/list.jl
@@ -73,6 +73,8 @@ struct ToList{T, stringtype, A, I} <: AbstractVector{T}
     inds::Vector{I}
 end
 
+origtype(::ToList{T, S, A, I}) where {T, S, A, I} = A
+
 function ToList(input; largelists::Bool=false)
     AT = eltype(input)
     ST = Base.nonmissingtype(AT)
@@ -190,10 +192,12 @@ function arrowvector(::ListKind, x, i, nl, fi, de, ded, meta; largelists::Bool=f
     offsets = Offsets(UInt8[], flat.inds)
     if eltype(flat) == UInt8 # binary or utf8string
         data = flat
+        T = origtype(flat)
     else
         data = arrowvector(flat, i, nl + 1, fi, de, ded, nothing; lareglists=largelists, kw...)
+        T = withmissing(eltype(x), Vector{eltype(data)})
     end
-    return List{eltype(x), eltype(flat.inds), typeof(data)}(UInt8[], validity, offsets, data, len, meta)
+    return List{T, eltype(flat.inds), typeof(data)}(UInt8[], validity, offsets, data, len, meta)
 end
 
 function compress(Z::Meta.CompressionType, comp, x::List{T, O, A}) where {T, O, A}

--- a/src/arraytypes/list.jl
+++ b/src/arraytypes/list.jl
@@ -109,7 +109,8 @@ Base.size(x::ToList) = (length(x.inds) == 0 ? 0 : x.inds[end],)
 
 function Base.pointer(A::ToList{UInt8}, i::Integer)
     chunk = searchsortedfirst(A.inds, i)
-    return pointer(A.data[chunk - 1])
+    chunk = chunk > length(A.inds) ? 1 : (chunk - 1)
+    return pointer(A.data[chunk])
 end
 
 @inline function index(A::ToList, i::Integer)

--- a/src/arraytypes/list.jl
+++ b/src/arraytypes/list.jl
@@ -48,7 +48,7 @@ Base.size(l::List) = (l.ℓ,)
     @boundscheck checkbounds(l, i)
     @inbounds lo, hi = l.offsets[i]
     S = Base.nonmissingtype(T)
-    K = ArrowTypes.ArrowKind(S)
+    K = ArrowTypes.ArrowKind(ArrowTypes.ArrowType(S))
     if ArrowTypes.isstringtype(K)
         if S !== T
             return l.validity[i] ? ArrowTypes.fromarrow(T, pointer(l.data, lo), hi - lo + 1) : missing

--- a/src/arraytypes/map.jl
+++ b/src/arraytypes/map.jl
@@ -33,18 +33,18 @@ Base.size(l::Map) = (l.ℓ,)
     @boundscheck checkbounds(l, i)
     @inbounds lo, hi = l.offsets[i]
     if Base.nonmissingtype(T) !== T
-        return l.validity[i] ? ArrowTypes.arrowconvert(T, Dict(x.key => x.value for x in view(l.data, lo:hi))) : missing
+        return l.validity[i] ? ArrowTypes.fromarrow(T, Dict(x.key => x.value for x in view(l.data, lo:hi))) : missing
     else
-        return ArrowTypes.arrowconvert(T, Dict(x.key => x.value for x in view(l.data, lo:hi)))
+        return ArrowTypes.fromarrow(T, Dict(x.key => x.value for x in view(l.data, lo:hi)))
     end
 end
 
 keyvalues(KT, ::Missing) = missing
 keyvalues(KT, x::AbstractDict) = [KT(k, v) for (k, v) in pairs(x)]
 
-arrowvector(::MapType, x::Map, i, nl, fi, de, ded, meta; kw...) = x
+arrowvector(::MapKind, x::Map, i, nl, fi, de, ded, meta; kw...) = x
 
-function arrowvector(::MapType, x, i, nl, fi, de, ded, meta; largelists::Bool=false, kw...)
+function arrowvector(::MapKind, x, i, nl, fi, de, ded, meta; largelists::Bool=false, kw...)
     len = length(x)
     validity = ValidityBitmap(x)
     ET = eltype(x)

--- a/src/arraytypes/map.jl
+++ b/src/arraytypes/map.jl
@@ -42,6 +42,8 @@ end
 keyvalues(KT, ::Missing) = missing
 keyvalues(KT, x::AbstractDict) = [KT(k, v) for (k, v) in pairs(x)]
 
+keyvaluetypes(::Type{NamedTuple{(:key, :value), Tuple{K, V}}}) where {K, V} = (K, V)
+
 arrowvector(::MapKind, x::Map, i, nl, fi, de, ded, meta; kw...) = x
 
 function arrowvector(::MapKind, x, i, nl, fi, de, ded, meta; largelists::Bool=false, kw...)
@@ -55,7 +57,8 @@ function arrowvector(::MapKind, x, i, nl, fi, de, ded, meta; largelists::Bool=fa
     flat = ToList(T[keyvalues(KT, y) for y in x]; largelists=largelists)
     offsets = Offsets(UInt8[], flat.inds)
     data = arrowvector(flat, i, nl + 1, fi, de, ded, nothing; lareglists=largelists, kw...)
-    return Map{ET, eltype(flat.inds), typeof(data)}(validity, offsets, data, len, meta)
+    K, V = keyvaluetypes(eltype(data))
+    return Map{withmissing(ET, Dict{K, V}), eltype(flat.inds), typeof(data)}(validity, offsets, data, len, meta)
 end
 
 function compress(Z::Meta.CompressionType, comp, x::A) where {A <: Map}

--- a/src/arraytypes/primitive.jl
+++ b/src/arraytypes/primitive.jl
@@ -63,9 +63,9 @@ end
     return v
 end
 
-arrowvector(::PrimitiveType, x::Primitive, i, nl, fi, de, ded, meta; kw...) = x
+arrowvector(::PrimitiveKind, x::Primitive, i, nl, fi, de, ded, meta; kw...) = x
 
-function arrowvector(::PrimitiveType, x, i, nl, fi, de, ded, meta; kw...)
+function arrowvector(::PrimitiveKind, x, i, nl, fi, de, ded, meta; kw...)
     validity = ValidityBitmap(x)
     return Primitive(eltype(x), UInt8[], validity, x, length(x), meta)
 end

--- a/src/arraytypes/primitive.jl
+++ b/src/arraytypes/primitive.jl
@@ -43,9 +43,9 @@ end
 @propagate_inbounds function Base.getindex(p::Primitive{T}, i::Integer) where {T}
     @boundscheck checkbounds(p, i)
     if T >: Missing
-        return @inbounds (p.validity[i] ? ArrowTypes.arrowconvert(T, p.data[i]) : missing)
+        return @inbounds (p.validity[i] ? ArrowTypes.fromarrow(T, p.data[i]) : missing)
     else
-        return @inbounds ArrowTypes.arrowconvert(T, p.data[i])
+        return @inbounds ArrowTypes.fromarrow(T, p.data[i])
     end
 end
 

--- a/src/arraytypes/struct.jl
+++ b/src/arraytypes/struct.jl
@@ -30,11 +30,13 @@ Base.size(s::Struct) = (s.ℓ,)
 
 isnamedtuple(::Type{<:NamedTuple}) = true
 isnamedtuple(T) = false
+istuple(::Type{<:Tuple}) = true
+istuple(T) = false
 
 @propagate_inbounds function Base.getindex(s::Struct{T}, i::Integer) where {T}
     @boundscheck checkbounds(s, i)
     NT = Base.nonmissingtype(T)
-    if isnamedtuple(NT)
+    if isnamedtuple(NT) || istuple(NT)
         if NT !== T
             return s.validity[i] ? NT(ntuple(j->s.data[j][i], fieldcount(NT))) : missing
         else

--- a/src/arraytypes/unions.jl
+++ b/src/arraytypes/unions.jl
@@ -26,6 +26,7 @@ end
 unionmode(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = T
 typeids(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = typeIds
 Base.eltype(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = U
+uniontype(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = Union{(fieldtype(U, i) for i = 1:fieldcount(U))...}
 
 ArrowTypes.ArrowKind(::Type{<:UnionT}) = ArrowTypes.UnionKind()
 
@@ -56,7 +57,7 @@ An `Arrow.DenseUnion`, in comparison to `Arrow.SparseUnion`, stores elements in 
 array, where each offset element is the index into one of the typed arrays. This allows a sort of "compression", where no extra space is
 used/allocated to store all the elements.
 """
-struct DenseUnion{T, S} <: ArrowVector{T}
+struct DenseUnion{T, U, S} <: ArrowVector{T}
     arrow::Vector{UInt8} # need to hold a reference to arrow memory blob
     arrow2::Vector{UInt8} # if arrow blob is compressed, need a 2nd reference for uncompressed offsets bytes
     typeIds::Vector{UInt8}
@@ -68,27 +69,27 @@ end
 Base.size(s::DenseUnion) = size(s.typeIds)
 nullcount(x::DenseUnion) = 0 # DenseUnion has no validity bitmap; only children do
 
-@propagate_inbounds function Base.getindex(s::DenseUnion{T}, i::Integer) where {T}
+@propagate_inbounds function Base.getindex(s::DenseUnion{T, UnionT{M, typeIds, U}}, i::Integer) where {T, M, typeIds, U}
     @boundscheck checkbounds(s, i)
     @inbounds typeId = s.typeIds[i]
     @inbounds off = s.offsets[i]
     @inbounds x = s.data[typeId + 1][off + 1]
-    return ArrowTypes.fromarrow(T, x)
+    return ArrowTypes.fromarrow(fieldtype(U, typeId + 1), x)
 end
 
-@propagate_inbounds function Base.setindex!(s::DenseUnion{UnionT{T, typeIds, U}}, v, i::Integer) where {T, typeIds, U}
-    @boundscheck checkbounds(s, i)
-    @inbounds typeId = s.typeIds[i]
-    typeids = typeIds === nothing ? (0:(fieldcount(U) - 1)) : typeIds
-    vtypeId = Int8(typeids[isatypeid(v, U)])
-    if typeId == vtypeId
-        @inbounds off = s.offsets[i]
-        @inbounds s.data[typeId +1][off + 1] = v
-    else
-        throw(ArgumentError("type of item to set $(typeof(v)) must match existing item $(fieldtype(U, typeid))"))
-    end
-    return v
-end
+# @propagate_inbounds function Base.setindex!(s::DenseUnion{UnionT{T, typeIds, U}}, v, i::Integer) where {T, typeIds, U}
+#     @boundscheck checkbounds(s, i)
+#     @inbounds typeId = s.typeIds[i]
+#     typeids = typeIds === nothing ? (0:(fieldcount(U) - 1)) : typeIds
+#     vtypeId = Int8(typeids[isatypeid(v, U)])
+#     if typeId == vtypeId
+#         @inbounds off = s.offsets[i]
+#         @inbounds s.data[typeId +1][off + 1] = v
+#     else
+#         throw(ArgumentError("type of item to set $(typeof(v)) must match existing item $(fieldtype(U, typeid))"))
+#     end
+#     return v
+# end
 
 # convenience wrappers for signaling that an array shoudld be written
 # as with dense/sparse union arrow buffers
@@ -180,7 +181,7 @@ An `Arrow.SparseUnion`, in comparison to `Arrow.DenseUnion`, stores elements in 
 array has the same length as the full array. This ends up with "wasted" space, since only one slot among the typed arrays is valid per full
 array element, but can allow for certain optimizations when each typed array has the same length.
 """
-struct SparseUnion{T, S} <: ArrowVector{T}
+struct SparseUnion{T, U, S} <: ArrowVector{T}
     arrow::Vector{UInt8} # need to hold a reference to arrow memory blob
     typeIds::Vector{UInt8}
     data::S # Tuple of ArrowVector
@@ -190,21 +191,21 @@ end
 Base.size(s::SparseUnion) = size(s.typeIds)
 nullcount(x::SparseUnion) = 0
 
-@propagate_inbounds function Base.getindex(s::SparseUnion{T}, i::Integer) where {T}
+@propagate_inbounds function Base.getindex(s::SparseUnion{T, UnionT{M, typeIds, U}}, i::Integer) where {T, M, typeIds, U}
     @boundscheck checkbounds(s, i)
     @inbounds typeId = s.typeIds[i]
     @inbounds x = s.data[typeId + 1][i]
-    return ArrowTypes.fromarrow(T, x)
+    return ArrowTypes.fromarrow(fieldtype(U, typeId + 1), x)
 end
 
-@propagate_inbounds function Base.setindex!(s::SparseUnion{UnionT{T, typeIds, U}}, v, i::Integer) where {T, typeIds, U}
-    @boundscheck checkbounds(s, i)
-    typeids = typeIds === nothing ? (0:(fieldcount(U) - 1)) : typeIds
-    vtypeId = Int8(typeids[isatypeid(v, U)])
-    @inbounds s.typeIds[i] = vtypeId
-    @inbounds s.data[vtypeId + 1][i] = v
-    return v
-end
+# @propagate_inbounds function Base.setindex!(s::SparseUnion{UnionT{T, typeIds, U}}, v, i::Integer) where {T, typeIds, U}
+#     @boundscheck checkbounds(s, i)
+#     typeids = typeIds === nothing ? (0:(fieldcount(U) - 1)) : typeIds
+#     vtypeId = Int8(typeids[isatypeid(v, U)])
+#     @inbounds s.typeIds[i] = vtypeId
+#     @inbounds s.data[vtypeId + 1][i] = v
+#     return v
+# end
 
 arrowvector(U::Union, x, i, nl, fi, de, ded, meta; denseunions::Bool=true, kw...) =
     arrowvector(denseunions ? DenseUnionVector(x) : SparseUnionVector(x), i, nl, fi, de, ded, meta; denseunions=denseunions, kw...)
@@ -213,16 +214,17 @@ arrowvector(::UnionKind, x::Union{DenseUnion, SparseUnion}, i, nl, fi, de, ded, 
 
 function arrowvector(::UnionKind, x, i, nl, fi, de, ded, meta; kw...)
     UT = eltype(x)
+    T = uniontype(UT)
     if unionmode(UT) == Meta.UnionMode.Dense
         x = x isa DenseUnionVector ? x.itr : x
         typeids, offsets, data = todense(UT, x)
         data2 = map(y -> arrowvector(y[2], i, nl + 1, y[1], de, ded, nothing; kw...), enumerate(data))
-        return DenseUnion{UT, typeof(data2)}(UInt8[], UInt8[], typeids, offsets, data2, meta)
+        return DenseUnion{T, UT, typeof(data2)}(UInt8[], UInt8[], typeids, offsets, data2, meta)
     else
         x = x isa SparseUnionVector ? x.itr : x
         typeids = sparsetypeids(UT, x)
         data3 = Tuple(arrowvector(ToSparseUnion(fieldtype(eltype(UT), j), x), i, nl + 1, j, de, ded, nothing; kw...) for j = 1:fieldcount(eltype(UT)))
-        return SparseUnion{UT, typeof(data3)}(UInt8[], typeids, data3, meta)
+        return SparseUnion{T, UT, typeof(data3)}(UInt8[], typeids, data3, meta)
     end
 end
 

--- a/src/arraytypes/unions.jl
+++ b/src/arraytypes/unions.jl
@@ -245,16 +245,16 @@ function makenodesbuffers!(col::Union{DenseUnion, SparseUnion}, fieldnodes, fiel
     len = length(col)
     nc = nullcount(col)
     push!(fieldnodes, FieldNode(len, nc))
-    @debug -1 "made field node: nodeidx = $(length(fieldnodes)), col = $(typeof(col)), len = $(fieldnodes[end].length), nc = $(fieldnodes[end].null_count)"
+    @debug 1 "made field node: nodeidx = $(length(fieldnodes)), col = $(typeof(col)), len = $(fieldnodes[end].length), nc = $(fieldnodes[end].null_count)"
     # typeIds buffer
     push!(fieldbuffers, Buffer(bufferoffset, len))
-    @debug -1 "made field buffer: bufferidx = $(length(fieldbuffers)), offset = $(fieldbuffers[end].offset), len = $(fieldbuffers[end].length), padded = $(padding(fieldbuffers[end].length, alignment))"
+    @debug 1 "made field buffer: bufferidx = $(length(fieldbuffers)), offset = $(fieldbuffers[end].offset), len = $(fieldbuffers[end].length), padded = $(padding(fieldbuffers[end].length, alignment))"
     bufferoffset += padding(len, alignment)
     if col isa DenseUnion
         # offsets buffer
         blen = sizeof(Int32) * len
         push!(fieldbuffers, Buffer(bufferoffset, blen))
-        @debug -1 "made field buffer: bufferidx = $(length(fieldbuffers)), offset = $(fieldbuffers[end].offset), len = $(fieldbuffers[end].length), padded = $(padding(fieldbuffers[end].length, alignment))"
+        @debug 1 "made field buffer: bufferidx = $(length(fieldbuffers)), offset = $(fieldbuffers[end].offset), len = $(fieldbuffers[end].length), padded = $(padding(fieldbuffers[end].length, alignment))"
         bufferoffset += padding(blen, alignment)
     end
     for child in col.data
@@ -264,15 +264,15 @@ function makenodesbuffers!(col::Union{DenseUnion, SparseUnion}, fieldnodes, fiel
 end
 
 function writebuffer(io, col::Union{DenseUnion, SparseUnion}, alignment)
-    @debug -1 "writebuffer: col = $(typeof(col))"
+    @debug 1 "writebuffer: col = $(typeof(col))"
     @debug 2 col
     # typeIds buffer
     n = writearray(io, UInt8, col.typeIds)
-    @debug -1 "writing array: col = $(typeof(col.typeIds)), n = $n, padded = $(padding(n, alignment))"
+    @debug 1 "writing array: col = $(typeof(col.typeIds)), n = $n, padded = $(padding(n, alignment))"
     writezeros(io, paddinglength(n, alignment))
     if col isa DenseUnion
         n = writearray(io, Int32, col.offsets)
-        @debug -1 "writing array: col = $(typeof(col.offsets)), n = $n, padded = $(padding(n, alignment))"
+        @debug 1 "writing array: col = $(typeof(col.offsets)), n = $n, padded = $(padding(n, alignment))"
         writezeros(io, paddinglength(n, alignment))
     end
     for child in col.data

--- a/src/arraytypes/unions.jl
+++ b/src/arraytypes/unions.jl
@@ -27,7 +27,7 @@ unionmode(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = T
 typeids(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = typeIds
 Base.eltype(::Type{UnionT{T, typeIds, U}}) where {T, typeIds, U} = U
 
-ArrowTypes.ArrowType(::Type{<:UnionT}) = ArrowTypes.UnionType()
+ArrowTypes.ArrowKind(::Type{<:UnionT}) = ArrowTypes.UnionType()
 
 # iterate a Julia Union{...} type, producing an array of unioned types
 function eachunion(U::Union, elems=nothing)

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -140,6 +140,13 @@ fromarrow(::Type{Union{Missing, T}}, x) where {T} = fromarrow(T, x)
 struct NullKind <: ArrowKind end
 
 ArrowKind(::Type{Missing}) = NullKind()
+ArrowKind(::Type{Nothing}) = NullKind()
+ArrowType(::Type{Nothing}) = Missing
+toarrow(::Nothing) = missing
+const NOTHING = Symbol("JuliaLang.Nothing")
+arrowname(::Type{Nothing}) = NOTHING
+JuliaType(::Val{NOTHING}, S) = Nothing
+fromarrow(::Type{Nothing}, ::Missing) = nothing
 
 "PrimitiveKind data is stored as plain bits in a single contiguous buffer"
 struct PrimitiveKind <: ArrowKind end
@@ -178,6 +185,7 @@ _symbol(ptr, len) = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), ptr, len
 fromarrow(::Type{Symbol}, ptr::Ptr{UInt8}, len::Int) = _symbol(ptr, len)
 
 ArrowKind(::Type{<:AbstractArray}) = ListKind()
+fromarrow(::Type{A}, x::AbstractVector{T}) where {A <: AbstractVector{T}} where {T} = x
 ArrowKind(::Type{<:AbstractSet}) = ListKind()
 ArrowType(::Type{T}) where {T <: AbstractSet{S}} where {S} = Vector{S}
 toarrow(x::AbstractSet) = collect(x)

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -108,7 +108,7 @@ The use of `Val(Symbol(...))` is to allow overloading a method on a specific log
 `JuliaType` is the native arrow serialized type. This can be useful for parametric Julia types that wish to correctly parameterize
 their custom type based on what was serialized.
 When defining [`ArrowTypes.arrowname`](@ref) and `ArrowTypes.JuliaType`, you may also want to implement [`ArrowTypes.fromarrow`]
-in order to customize how a custom type `T` should be constructed from the native arrow data type. See its docs for mmore details.
+in order to customize how a custom type `T` should be constructed from the native arrow data type. See its docs for more details.
 """
 function JuliaType end
 JuliaType(val, S) = nothing

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -57,7 +57,7 @@ ArrowKind(::Type{T}) where {T} = isprimitivetype(T) ? PrimitiveKind() : StructKi
 Interface method to define the natively supported arrow type `S` that a given type `T` should be converted to before serializing.
 Useful when a custom type wants a "serialization hook" or otherwise needs to be transformed/converted into a natively
 supported arrow type for serialization. If a type defines `ArrowType`, it must also define a corresponding
-[`ArrowTypes.toarrow(::Type{S}, x::T)`](@ref) method which does the actual conversion from `T` to `S`.
+[`ArrowTypes.toarrow(x::T)`](@ref) method which does the actual conversion from `T` to `S`.
 Note that custom structs defined like `struct T` or `mutable struct T` are natively supported in serialization, so unless
 _additional_ transformation/customization is desired, a custom type `T` can serialize with no `ArrowType` definition (by default,
 each field of a struct is serialized, using the results of `fieldnames(T)` and `getfield(x, i)`).

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -178,6 +178,12 @@ _symbol(ptr, len) = ccall(:jl_symbol_n, Ref{Symbol}, (Ptr{UInt8}, Int), ptr, len
 fromarrow(::Type{Symbol}, ptr::Ptr{UInt8}, len::Int) = _symbol(ptr, len)
 
 ArrowKind(::Type{<:AbstractArray}) = ListKind()
+ArrowKind(::Type{<:AbstractSet}) = ListKind()
+ArrowType(::Type{T}) where {T <: AbstractSet{S}} where {S} = Vector{S}
+toarrow(x::AbstractSet) = collect(x)
+const SET = Symbol("JuliaLang.Set")
+arrowname(::Type{<:AbstractSet}) = SET
+JuliaType(::Val{SET}, ::Type{T}) where {T <: AbstractVector{S}} where {S} = Set{S}
 
 "FixedSizeListKind data are stored in a single contiguous buffer; individual elements can be computed based on the fixed size of the lists"
 struct FixedSizeListKind{N, T} <: ArrowKind end

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -224,7 +224,6 @@ struct StructKind <: ArrowKind end
 
 ArrowKind(::Type{<:NamedTuple}) = StructKind()
 
-fromarrow(::Type{T}; kw...) where {T} = fromarrow(T, kw.data)
 fromarrow(::Type{NamedTuple{names, types}}, x::NamedTuple{names, types}) where {names, types <: Tuple} = x
 fromarrow(::Type{T}, x::NamedTuple) where {T} = fromarrow(T, Tuple(x)...)
 
@@ -233,8 +232,8 @@ const TUPLE = Symbol("JuliaLang.Tuple")
 # needed to disambiguate the FixedSizeList case for NTuple
 arrowname(::Type{NTuple{N, T}}) where {N, T} = EMPTY_SYMBOL
 arrowname(::Type{T}) where {T <: Tuple} = TUPLE
-JuliaType(::Val{TUPLE}, ::Type{NamedTuple{names, types}}) where {names, types} = types
-fromarrow(::Type{<:Tuple}, x::NamedTuple) = Tuple(x)
+JuliaType(::Val{TUPLE}, ::Type{NamedTuple{names, types}}) where {names, types <: Tuple} = types
+fromarrow(::Type{T}, x::NamedTuple) where {T <: Tuple} = Tuple(x)
 
 "MapKind data are stored similarly to ListKind, where elements are flattened, and a 2nd offsets buffer contains the individual list element length data"
 struct MapKind <: ArrowKind end

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -146,7 +146,7 @@ function juliaeltype(f::Meta.Field, x::Meta.Decimal, convert)
     return Decimal{x.precision, x.scale, x.bitWidth == 256 ? Int256 : Int128}
 end
 
-ArrowTypes.ArrowKind(::Type{<:Decimal}) = PrimitiveType()
+ArrowTypes.ArrowKind(::Type{<:Decimal}) = PrimitiveKind()
 
 function arrowtype(b, ::Type{Decimal{P, S, T}}) where {P, S, T}
     Meta.decimalStart(b)
@@ -160,7 +160,7 @@ Base.write(io::IO, x::Decimal) = Base.write(io, x.value)
 
 abstract type ArrowTimeType end
 Base.write(io::IO, x::ArrowTimeType) = Base.write(io, x.x)
-ArrowTypes.ArrowKind(::Type{<:ArrowTimeType}) = PrimitiveType()
+ArrowTypes.ArrowKind(::Type{<:ArrowTimeType}) = PrimitiveKind()
 
 struct Date{U, T} <: ArrowTimeType
     x::T
@@ -191,7 +191,7 @@ Base.convert(::Type{DATE}, x::Dates.Date) = DATE(Int32(Dates.value(x) - UNIX_EPO
 const UNIX_EPOCH_DATETIME = Dates.value(Dates.DateTime(1970))
 Base.convert(::Type{Date{Meta.DateUnit.MILLISECOND, Int64}}, x::Dates.DateTime) = Date{Meta.DateUnit.MILLISECOND, Int64}(Int64(Dates.value(x) - UNIX_EPOCH_DATETIME))
 
-ArrowTypes.ArrowKind(::Type{Dates.Date}) = ArrowTypes.PrimitiveType()
+ArrowTypes.ArrowKind(::Type{Dates.Date}) = ArrowTypes.PrimitiveKind()
 ArrowTypes.toarrow(x::Dates.Date) = convert(DATE, x)
 const DATE_SYMBOL = Symbol("JuliaLang.Date")
 ArrowTypes.arrowname(::Type{Dates.Date}) = DATE_SYMBOL
@@ -223,7 +223,7 @@ end
 
 Base.convert(::Type{TIME}, x::Dates.Time) = TIME(Dates.value(x))
 
-ArrowTypes.ArrowKind(::Type{Dates.Time}) = ArrowTypes.PrimitiveType()
+ArrowTypes.ArrowKind(::Type{Dates.Time}) = ArrowTypes.PrimitiveKind()
 ArrowTypes.toarrow(x::Dates.Time) = convert(TIME, x)
 const TIME_SYMBOL = Symbol("JuliaLang.Time")
 ArrowTypes.arrowname(::Type{Dates.Time}) = TIME_SYMBOL
@@ -260,13 +260,13 @@ function arrowtype(b, ::Type{Timestamp{U, TZ}}) where {U, TZ}
     return Meta.Timestamp, Meta.timestampEnd(b), nothing
 end
 
-ArrowTypes.ArrowKind(::Type{Dates.DateTime}) = ArrowTypes.PrimitiveType()
+ArrowTypes.ArrowKind(::Type{Dates.DateTime}) = ArrowTypes.PrimitiveKind()
 ArrowTypes.toarrow(x::Dates.DateTime) = convert(DATETIME, x)
 const DATETIME_SYMBOL = Symbol("JuliaLang.DateTime")
 ArrowTypes.arrowname(::Type{Dates.DateTime}) = DATETIME_SYMBOL
 ArrowTypes.fromarrow(::Val{DATETIME_SYMBOL}, x::DATETIME) = convert(Dates.DateTime, x)
 
-ArrowTypes.ArrowKind(::Type{ZonedDateTime}) = ArrowTypes.PrimitiveType()
+ArrowTypes.ArrowKind(::Type{ZonedDateTime}) = ArrowTypes.PrimitiveKind()
 ArrowTypes.toarrow(x::ZonedDateTime) = convert(Timestamp{Meta.TimeUnit.MILLISECOND, Symbol(x[1].timezone), x)
 const ZONEDDATETIME_SYMBOL = Symbol("JuliaLang.ZonedDateTime")
 ArrowTypes.arrowname(::Type{ZonedDateTime}) = ZONEDDATETIME_SYMBOL
@@ -318,7 +318,7 @@ arrowperiodtype(::Type{Dates.Nanosecond}) = Meta.TimeUnit.NANOSECOND
 
 Base.convert(::Type{Duration{U}}, x::Dates.Period) where {U} = Duration{U}(Dates.value(periodtype(U)(x)))
 
-ArrowTypes.ArrowKind(::Type{<:Dates.Period}) = ArrowTypes.PrimitiveType()
+ArrowTypes.ArrowKind(::Type{<:Dates.Period}) = ArrowTypes.PrimitiveKind()
 ArrowTypes.toarrow(x::P) where {P <: Dates.Period} = convert(Duration{arrowperiodtype(P)}, x)
 ArrowTypes.arrowname(::Type{P}) where {P <: Dates.Period} = Symbol("JuliaLang.", P)
 for P in (Dates.Year, Dates.Quarter, Dates.Month, Dates.Week, Dates.Day, Dates.Hour, Dates.Minute,

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -49,7 +49,8 @@ function juliaeltype(f::Meta.Field, meta::Dict{String, String}, convert::Bool)
     # end deprecated
     if haskey(meta, "ARROW:extension:name")
         typename = meta["ARROW:extension:name"]
-        JT = ArrowTypes.JuliaType(Val(Symbol(typename)), maybemissing(TT))
+        metadata = get(meta, "ARROW:extension:metadata", "")
+        JT = ArrowTypes.JuliaType(Val(Symbol(typename)), maybemissing(TT), metadata)
         if JT !== nothing
             return f.nullable ? Union{JT, Missing} : JT
         else

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -49,11 +49,11 @@ function juliaeltype(f::Meta.Field, meta::Dict{String, String}, convert::Bool)
     # end deprecated
     if haskey(meta, "ARROW:extension:name")
         typename = meta["ARROW:extension:name"]
-        JT = ArrowTypes.JuliaType(Val(Symbol(typename)), TT)
+        JT = ArrowTypes.JuliaType(Val(Symbol(typename)), maybemissing(TT))
         if JT !== nothing
             return f.nullable ? Union{JT, Missing} : JT
         else
-            @warn "unsupported ARROW:extension:name type: \"$typename\""
+            @warn "unsupported ARROW:extension:name type: \"$typename\", arrow type = $TT"
         end
     end
     return something(TTT, T)
@@ -342,7 +342,7 @@ ArrowTypes.ArrowType(::Type{P}) where {P <: Dates.Period} = Duration{arrowperiod
 ArrowTypes.toarrow(x::P) where {P <: Dates.Period} = convert(Duration{arrowperiodtype(P)}, x)
 const PERIOD_SYMBOL = Symbol("JuliaLang.Dates.Period")
 ArrowTypes.arrowname(::Type{P}) where {P <: Dates.Period} = PERIOD_SYMBOL
-ArrowTypes.JuliaType(::Val{PERIOD_SYMBOL}, S::Duration{U}) where {U} = periodtype(U)
+ArrowTypes.JuliaType(::Val{PERIOD_SYMBOL}, ::Type{Duration{U}}) where {U} = periodtype(U)
 ArrowTypes.fromarrow(::Type{P}, x::Duration{U}) where {P <: Dates.Period, U} = convert(P, x)
 
 # nested types; call juliaeltype recursively on nested children

--- a/src/table.jl
+++ b/src/table.jl
@@ -520,7 +520,7 @@ function build(f::Meta.Field, L::Meta.Null, batch, rb, de, nodeidx, bufferidx, c
     @debug 2 "building array: L = $L"
     meta = buildmetadata(f.custom_metadata)
     T = juliaeltype(f, meta, convert)
-    return NullVector{maybemissing(T)}(MissingVector(rb.nodes[nodeidx].length), meta), nodeidx, bufferidx
+    return NullVector{maybemissing(T)}(MissingVector(rb.nodes[nodeidx].length), meta), nodeidx + 1, bufferidx
 end
 
 # primitives

--- a/src/table.jl
+++ b/src/table.jl
@@ -518,7 +518,9 @@ end
 
 function build(f::Meta.Field, L::Meta.Null, batch, rb, de, nodeidx, bufferidx, convert)
     @debug 2 "building array: L = $L"
-    return MissingVector(rb.nodes[nodeidx].length), nodeidx + 1, bufferidx
+    meta = buildmetadata(f.custom_metadata)
+    T = juliaeltype(f, meta, convert)
+    return NullVector{maybemissing(T)}(MissingVector(rb.nodes[nodeidx].length), meta), nodeidx, bufferidx
 end
 
 # primitives

--- a/src/table.jl
+++ b/src/table.jl
@@ -533,9 +533,6 @@ function build(f::Meta.Field, ::L, batch, rb, de, nodeidx, bufferidx, convert) w
     bytes, A = reinterp(Base.nonmissingtype(T), batch, buffer, rb.compression)
     len = rb.nodes[nodeidx].length
     T = juliaeltype(f, meta, convert)
-    if JuliaType(T) !== nothing
-        T = JuliaType(T)
-    end
     @debug 2 "final julia type for primitive: T = $T"
     return Primitive(T, bytes, validity, A, len, meta), nodeidx + 1, bufferidx + 1
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -178,8 +178,8 @@ Tables.getcolumn(t::Table, i::Int) = columns(t)[i]
 Tables.getcolumn(t::Table, nm::Symbol) = lookup(t)[nm]
 
 # high-level user API functions
-Table(io::IO, pos::Integer=1, len=nothing; convert::Bool=true) = Table(Base.read(io), pos, len; convert=convert)
-Table(str::String, pos::Integer=1, len=nothing; convert::Bool=true) = isfile(str) ? Table(Mmap.mmap(str), pos, len; convert=convert) :
+Table(io::IO, pos::Integer=1, len=nothing; kw...) = Table(Base.read(io), pos, len; kw...)
+Table(str::String, pos::Integer=1, len=nothing; kw...) = isfile(str) ? Table(Mmap.mmap(str), pos, len; kw...) :
     throw(ArgumentError("$str is not a file"))
 
 # will detect whether we're reading a Table from a file or stream
@@ -507,10 +507,11 @@ function build(f::Meta.Field, L::Meta.Union, batch, rb, de, nodeidx, bufferidx, 
     data = Tuple(vecs)
     meta = buildmetadata(f.custom_metadata)
     T = juliaeltype(f, meta, convert)
+    UT = UnionT(f, convert)
     if L.mode == Meta.UnionMode.Dense
-        B = DenseUnion{T, typeof(data)}(bytes, bytes2, typeIds, offsets, data, meta)
+        B = DenseUnion{T, UT, typeof(data)}(bytes, bytes2, typeIds, offsets, data, meta)
     else
-        B = SparseUnion{T, typeof(data)}(bytes, typeIds, data, meta)
+        B = SparseUnion{T, UT, typeof(data)}(bytes, typeIds, data, meta)
     end
     return B, nodeidx, bufferidx
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -533,6 +533,9 @@ function build(f::Meta.Field, ::L, batch, rb, de, nodeidx, bufferidx, convert) w
     bytes, A = reinterp(Base.nonmissingtype(T), batch, buffer, rb.compression)
     len = rb.nodes[nodeidx].length
     T = juliaeltype(f, meta, convert)
+    if JuliaType(T) !== nothing
+        T = JuliaType(T)
+    end
     @debug 2 "final julia type for primitive: T = $T"
     return Primitive(T, bytes, validity, A, len, meta), nodeidx + 1, bufferidx + 1
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -118,6 +118,8 @@ Base.eltype(x::Converter{T, A}) where {T, A} = T
 Base.getindex(x::Converter{T}, i::Int) where {T} = ArrowTypes.arrowconvert(T, getindex(x.data, i))
 
 maybemissing(::Type{T}) where {T} = T === Missing ? Missing : Base.nonmissingtype(T)
+withmissing(U::Union, S) = U >: Missing ? Union{Missing, S} : S
+withmissing(T, S) = T === Missing ? Union{Missing, S} : S
 
 function getfooter(filebytes)
     len = readbuffer(filebytes, length(filebytes) - 9, Int32)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,19 +104,6 @@ end
 # given a number of unique values; what dict encoding _index_ type is most appropriate
 encodingtype(n) = n < div(typemax(Int8), 2) ? Int8 : n < div(typemax(Int16), 2) ? Int16 : n < div(typemax(Int32), 2) ? Int32 : Int64
 
-# lazily call convert(T, x) on getindex for each x in data
-struct Converter{T, A} <: AbstractVector{T}
-    data::A
-end
-
-converter(::Type{T}, x::A) where {T, A} = Converter{eltype(A) >: Missing ? Union{T, Missing} : T, A}(x)
-converter(::Type{T}, x::ChainedVector{A}) where {T, A} = ChainedVector([converter(T, x) for x in x.arrays])
-
-Base.IndexStyle(::Type{<:Converter}) = Base.IndexLinear()
-Base.size(x::Converter) = (length(x.data),)
-Base.eltype(x::Converter{T, A}) where {T, A} = T
-Base.getindex(x::Converter{T}, i::Int) where {T} = ArrowTypes.arrowconvert(T, getindex(x.data, i))
-
 maybemissing(::Type{T}) where {T} = T === Missing ? Missing : Base.nonmissingtype(T)
 
 function getfooter(filebytes)

--- a/src/write.jl
+++ b/src/write.jl
@@ -88,6 +88,9 @@ function write(io::IO, tbl; largelists::Bool=false, compress::Union{Nothing, Sym
 end
 
 function write(io, source, writetofile, largelists, compress, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks)
+    if ntasks < 1
+        throw(ArgumentError("ntasks keyword argument must be > 0; pass `ntasks=1` to disable multithreaded writing"))
+    end
     if compress === :lz4
         compress = LZ4_FRAME_COMPRESSOR
     elseif compress === :zstd
@@ -95,9 +98,10 @@ function write(io, source, writetofile, largelists, compress, denseunions, dicte
     elseif compress isa Symbol
         throw(ArgumentError("unsupported compress keyword argument value: $compress. Valid values include `:lz4` or `:zstd`"))
     end
-    if ntasks < 1
-        throw(ArgumentError("ntasks keyword argument must be > 0; pass `ntasks=1` to disable multithreaded writing"))
-    end
+    # TODO: we're probably not threadsafe if user passes own single compressor instance + ntasks > 1
+    # if ntasks > 1 && compres !== nothing && !(compress isa Vector)
+    #     compress = Threads.resize_nthreads!([compress])
+    # end
     if writetofile
         @debug 1 "starting write of arrow formatted file"
         Base.write(io, "ARROW1\0\0")

--- a/src/write.jl
+++ b/src/write.jl
@@ -347,7 +347,7 @@ function makeschemamsg(sch::Tables.Schema, columns)
 end
 
 function fieldoffset(b, name, col)
-    nameoff = FlatBuffers.createstring!(b, String(name))
+    nameoff = FlatBuffers.createstring!(b, string(name))
     T = eltype(col)
     nullable = T >: Missing
     # check for custom metadata

--- a/test/arrowjson.jl
+++ b/test/arrowjson.jl
@@ -368,10 +368,10 @@ function FieldData(nm, ::Base.Type{T}, col, dictencodings) where {T}
             OFFSET = Offsets(OFFSET)
             push!(children, FieldData("item", eltype(S), Arrow.flatten(skipmissing(col)), dictencodings))
         elseif S <: NTuple
-            if Arrow.ArrowTypes.gettype(S) == UInt8
+            if Arrow.ArrowTypes.gettype(Arrow.ArrowTypes.ArrowKind(S)) == UInt8
                 DATA = [ismissing(x) ? Arrow.ArrowTypes.default(S) : String(collect(x)) for x in col]
             else
-                push!(children, FieldData("item", Arrow.ArrowTypes.gettype(S), Arrow.flatten(coalesce(x, Arrow.ArrowTypes.default(S)) for x in col), dictencodings))
+                push!(children, FieldData("item", Arrow.ArrowTypes.gettype(Arrow.ArrowTypes.ArrowKind(S)), Arrow.flatten(coalesce(x, Arrow.ArrowTypes.default(S)) for x in col), dictencodings))
             end
         elseif S <: NamedTuple
             for (nm, typ) in zip(fieldnames(S), fieldtypes(S))
@@ -523,12 +523,12 @@ function Base.getindex(x::ArrowArray{T}, i::Base.Int) where {T}
         A = ArrowArray(x.field.children[1], x.fielddata.children[1], x.dictionaries)
         return Dict(y.key => y.value for y in A[(offs[i] + 1):offs[i + 1]])
     elseif S <: Tuple
-        if Arrow.ArrowTypes.gettype(S) == UInt8
+        if Arrow.ArrowTypes.gettype(Arrow.ArrowTypes.ArrowKind(S)) == UInt8
             A = x.fielddata.DATA
             return Tuple(map(UInt8, collect(A[i][1:x.field.type.byteWidth])))
         else
             sz = x.field.type.listSize
-            A = ArrowArray{Arrow.ArrowTypes.gettype(S)}(x.field.children[1], x.fielddata.children[1], x.dictionaries)
+            A = ArrowArray{Arrow.ArrowTypes.gettype(Arrow.ArrowTypes.ArrowKind(S))}(x.field.children[1], x.fielddata.children[1], x.dictionaries)
             off = (i - 1) * sz + 1
             return Tuple(A[off:(off + sz - 1)])
         end

--- a/test/dates.jl
+++ b/test/dates.jl
@@ -46,9 +46,7 @@ Arrow.ArrowTypes.registertype!(WrappedZonedDateTime, WrappedZonedDateTime)
             time = T(Dates.now())
         end
         table = (; x = [missing, missing, time, missing, time])
-        io = IOBuffer()
-        Arrow.write(io, table)
-        seekstart(io)
+        io = Arrow.tobuffer(table)
         tbl = Arrow.Table(io)
         @test isequal(collect(tbl.x), table.x)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,6 +245,10 @@ io = IOBuffer()
 tbl = Arrow.Table(Arrow.tobuffer((sets = [Set([1,2,3]), Set([1,2,3])],)))
 @test eltype(tbl.sets) <: Set
 
+# 85
+tbl = Arrow.Table(Arrow.tobuffer((tups = [(1, 3.14, "hey"), (1, 3.14, "hey")],)))
+@test eltype(tbl.tups) <: Tuple
+
 end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,9 +42,7 @@ for file in readdir(joinpath(dirname(pathof(Arrow)), "../test/arrowjson"))
     jsonfile = joinpath(joinpath(dirname(pathof(Arrow)), "../test/arrowjson"), file)
     println("integration test for $jsonfile")
     df = ArrowJSON.parsefile(jsonfile);
-    io = IOBuffer()
-    Arrow.write(io, df)
-    seekstart(io)
+    io = Arrow.tobuffer(df)
     tbl = Arrow.Table(io; convert=false);
     @test isequal(df, tbl)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -153,6 +153,9 @@ tt = Arrow.Table(Arrow.tobuffer(t))
 
 # automatic custom struct serialization/deserialization
 t = (col1=[CustomStruct(1, 2.3, "hey"), CustomStruct(4, 5.6, "there")],)
+
+Arrow.ArrowTypes.arrowname(::Type{CustomStruct}) = Symbol("JuliaLang.CustomStruct")
+Arrow.ArrowTypes.JuliaType(::Val{Symbol("JuliaLang.CustomStruct")}, S) = CustomStruct
 tt = Arrow.Table(Arrow.tobuffer(t))
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
@@ -167,8 +170,8 @@ tt = Arrow.Table(Arrow.tobuffer(t))
 u = 0x6036fcbd20664bd8a65cdfa25434513f
 @test Arrow.ArrowTypes.arrowconvert(UUID, (value=u,)) === UUID(u)
 @test Arrow.ArrowTypes.arrowconvert(UUID, u) === UUID(u)
-@test Arrow.ArrowTypes.gettype(UUID) == UInt8
-@test Arrow.ArrowTypes.getsize(UUID) == 16
+@test Arrow.ArrowTypes.gettype(Arrow.ArrowTypes.ArrowKind(UUID)) == UInt8
+@test Arrow.ArrowTypes.getsize(Arrow.ArrowTypes.ArrowKind(UUID)) == 16
 
 # 98
 t = (a = [Nanosecond(0), Nanosecond(1)], b = [uuid4(), uuid4()], c = [missing, Nanosecond(1)])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,6 +241,10 @@ t = Tables.partitioner(
 io = IOBuffer()
 @test_throws ErrorException Arrow.write(io, t)
 
+# 75
+tbl = Arrow.Table(Arrow.tobuffer((sets = [Set([1,2,3]), Set([1,2,3])],)))
+@test eltype(tbl.sets) <: Set
+
 end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -165,7 +165,7 @@ tt = Arrow.Table(Arrow.tobuffer(t))
 @test length(tt) == length(t)
 @test all(isequal.(values(t), values(tt)))
 
-# 89 etc. - test deprecation paths for old UUID autoconversion + UUID FixedSizeListType overloads
+# 89 etc. - test deprecation paths for old UUID autoconversion + UUID FixedSizeListKind overloads
 u = 0x6036fcbd20664bd8a65cdfa25434513f
 @test Arrow.ArrowTypes.arrowconvert(UUID, (value=u,)) === UUID(u)
 @test Arrow.ArrowTypes.arrowconvert(UUID, u) === UUID(u)
@@ -186,7 +186,7 @@ x2 = Arrow.toarrowvector(x)
 
 # some dict encoding coverage
 
-# signed indices for DictEncodedType #112 #113 #114
+# signed indices for DictEncodedKind #112 #113 #114
 av = Arrow.toarrowvector(PooledArray(repeat(["a", "b"], inner = 5)))
 @test isa(first(av.indices), Signed)
 


### PR DESCRIPTION
Ok, this PR is in response to issues like #135, #134, #132, #88, #85, and a few conversations on slack. In short, the automatic registering of `struct` types is pretty smelly, we're not set up to handle parametric cases very well, and the usage of Dicts internally is fairly un-Julian. We were also pretty inconsistent internally around how things were handled; some types were baked into the `registertype!` machinery (Symbol, Char), some had custom `ArrowType` definitions (UUID), and some were baked in even further to the array conversion code (all the time types). The proposal in this PR is roughly as follows, though I encourage anyone interested to read through the documented interface methods in the arrowtypes.jl file:

* Rename `ArrowType` to `ArrowKind`; it was getting all too muddled together that there is a specific set of native ___types___ that arrow support, and those types all fall under a smaller set of ___physical layout configurations___; the former is now tied to a "new" `ArrowType`, while the latter is now `ArrowKind`. Most custom types don't need to worry about overloading `ArrowKind`, because we define them generally on abstract types in the `ArrowTypes` module already (like `AbstractArray`, `AbstractDict`, etc.). Custom types will more often overload `ArrowType`, which maps a user's custom type to a natively supported arrow type; users should note that custom structs defined like `struct` or `mutable struct`, however, ___are___ natively supported for serialization, but without additional definitions (`arrowname`, `JuliaType`), there is no automatic deserialization
* If I define a custom `ArrowType` definition for my type, then I'm required to also define an `ArrowTypes.toarrow(x::T)` method that converts my type to the native arrow type I defined in `ArrowType`; this provides a serialization "hook" to do any desired transformation; note however, that defining `ArrowTypes.toarrow` ___doesn't___ require having an `ArrowType` definition; I may want to simply ignore a field or two in my custom struct, which I can do by defining `toarrow` and dropping the fields by returning a pared down struct or NamedTuple
* If I want my custom type to be deserializable, I need to implement two methods: `ArrowTypes.arrowname(T) => Symbol`, and `ArrowTypes.JuliaType(::Val{Symbol(name)}, S) = T`. The first takes my custom type as sole argument, and returns a `Symbol` of what my custom type will have stored in the column schema metadata. The latter definition will overload a `Val` wrapping my symbol name from `arrowname` (a not-uncommon Julia technique for value dispatch), and the native arrow serialized type as 2nd argument (`S`). These two definitions allow the "tagging" of my custom type during serialization (`arrowname`) and the conversion from native arrow type to my custom type during deserialization (`JuliaType`). In `JuliaType`, having the native arrow type as 2nd argument allows for parametric types to define a single `arrowname`, and rely on the serialized type to re-parameterize their custom type. Custom types may also choose to just include parameters in their `arrowname` definition; as long as a corresponding `JuliaType` definition exists that exactly matches `Val` argument, all should be well
* The final new interface method is `ArrowTypes.fromarrow`, which provides a deserialization "hook". It uses the result of `JuliaType` definition to provide the native arrow objects as arguments and custom types can then "construct themselves" appropriately.

All in all, I like the power and flexibility of the new system. I think it follows more traditional Julia dispatch patterns, while providing enough customizability to cover necessary use-cases. 

The current test suite passes for me locally, but I have run into an occasional race-condition when reading I believe. I'm going to look more into that. I purposely changed as little as possible in the test suite because I wanted this PR to be as non-breaking as possible. I don't think I'm aware of anyone who was using/defining things with `ArrowTypes.ArrowType` or other internals, which weren't really documented anyway, because I kind of knew it would need an overhaul at some point. I've kept the registertype!` machinery in place for now to avoid breaking things too much.

I'd appreciate any feedback/concerns if people have them. My plan as of now is to go through all the type-related issues and ensure we can now handle the requests, fix any bugs, and add additional tests around some of the new functionality.