### PR TITLE
ability to append partitions to existing arrow files

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -92,6 +92,7 @@ include("arraytypes/arraytypes.jl")
 include("eltypes.jl")
 include("table.jl")
 include("write.jl")
+include("append.jl")
 
 const LZ4_FRAME_COMPRESSOR = LZ4FrameCompressor[]
 const ZSTD_COMPRESSOR = ZstdCompressor[]

--- a/src/append.jl
+++ b/src/append.jl
@@ -187,14 +187,6 @@ function table_info(bytes::Vector{UInt8}; convert::Bool=true)
     Tables.Schema(names, types), dictencodings, compression_codec
 end
 
-function footer_offset(bytes::Vector{UInt8})
-    magic_len = length(FILE_FORMAT_MAGIC_BYTES)
-    startoffset = length(bytes) - magic_len - sizeof(Int32) + 1
-    endoffset = length(bytes) - magic_len
-
-    read(IOBuffer(bytes[startoffset:endoffset]), Int32) + magic_len + sizeof(Int32)
-end
-
 function is_stream_format(file::String)
     open(file) do io
         is_stream_format(io, true)
@@ -211,31 +203,6 @@ function is_stream_format(bytes::Vector{UInt8})
     else
         return true
     end
-end
-
-function convert_to_stream_format(file::String; kwargs...)
-    mktemp() do path, io
-        convert_to_stream_format(file, io; kwargs...)
-        close(io)
-        cp(path, file; force=true)
-    end
-    nothing
-end
-function convert_to_stream_format(source::String, dest::String; kwargs...)
-    open(dest, "w") do destio
-        convert_to_stream_format(source, destio; kwargs...)
-    end
-    nothing
-end
-function convert_to_stream_format(source::String, destio::IO; kwargs...)
-    open(source) do sourceio
-        convert_to_stream_format(sourceio, destio; kwargs...)
-    end
-    nothing
-end
-function convert_to_stream_format(sourceio::IO, destio::IO; kwargs...)
-    write(destio, Stream(sourceio); file=false, kwargs...)
-    nothing
 end
 
 function is_equivalent_schema(sch1::Tables.Schema, sch2::Tables.Schema)

--- a/src/append.jl
+++ b/src/append.jl
@@ -105,16 +105,17 @@ function append(io::IO, source, arrow_schema, compress, largelists, denseunions,
             error("fatal error writing arrow data")
         end
         @debug 1 "processing table partition i = $i"
-        tbl_schema = Tables.schema(tbl)
+        tbl_cols = Tables.columns(tbl)
+        tbl_schema = Tables.schema(tbl_cols)
 
         if !is_equivalent_schema(arrow_schema, tbl_schema)
             throw(ArgumentError("Table schema does not match existing arrow file schema"))
         end
 
         if threaded
-            Threads.@spawn process_partition(tbl, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
+            Threads.@spawn process_partition(tbl_cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
         else
-            @async process_partition(tbl, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
+            @async process_partition(tbl_cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
         end
     end
     if anyerror[]

--- a/src/append.jl
+++ b/src/append.jl
@@ -1,0 +1,247 @@
+"""
+    Arrow.append(file::String, tbl)
+    tbl |> Arrow.append(io_or_file)
+
+Append any [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible
+`tbl` to an existing arrow formatted file.
+
+Multiple record batches will be written based on the number of
+`Tables.partitions(tbl)` that are provided; by default, this is just
+one for a given table, but some table sources support automatic
+partitioning. Note you can turn multiple table objects into partitions
+by doing `Tables.partitioner([tbl1, tbl2, ...])`, but note that
+each table must have the exact same `Tables.Schema`.
+
+By default, `Arrow.append` will use multiple threads to write multiple
+record batches simultaneously (e.g. if julia is started with `julia -t 8`
+or the `JULIA_NUM_THREADS` environment variable is set).
+
+Supported keyword arguments to `Arrow.append` include:
+  * `alignment::Int=8`: specify the number of bytes to align buffers to when written in messages; strongly recommended to only use alignment values of 8 or 64 for modern memory cache line optimization
+  * `dictencode::Bool=false`: whether all columns should use dictionary encoding when being written; to dict encode specific columns, wrap the column/array in `Arrow.DictEncode(col)`
+  * `dictencodenested::Bool=false`: whether nested data type columns should also dict encode nested arrays/buffers; other language implementations [may not support this](https://arrow.apache.org/docs/status.html)
+  * `denseunions::Bool=true`: whether Julia `Vector{<:Union}` arrays should be written using the dense union layout; passing `false` will result in the sparse union layout
+  * `largelists::Bool=false`: causes list column types to be written with Int64 offset arrays; mainly for testing purposes; by default, Int64 offsets will be used only if needed
+  * `maxdepth::Int=$DEFAULT_MAX_DEPTH`: deepest allowed nested serialization level; this is provided by default to prevent accidental infinite recursion with mutually recursive data structures
+  * `ntasks::Int`: number of concurrent threaded tasks to allow while writing input partitions out as arrow record batches; default is no limit; to disable multithreaded writing, pass `ntasks=1`
+"""
+function append end
+
+append(file::String; kw...) = x -> append(file::String, x; kw...)
+
+function append(file::String, tbl;
+        largelists::Bool=false,
+        denseunions::Bool=true,
+        dictencode::Bool=false,
+        dictencodenested::Bool=false,
+        alignment::Int=8,
+        maxdepth::Int=DEFAULT_MAX_DEPTH,
+        ntasks=Inf)
+    if ntasks < 1
+        throw(ArgumentError("ntasks keyword argument must be > 0; pass `ntasks=1` to disable multithreaded writing"))
+    end
+
+    if !is_stream_format(file)
+        throw(ArgumentError("append is supported only to files in arrow stream format"))
+    end
+
+    open(file, "r+") do io
+        bytes = Mmap.mmap(io)
+        arrow_schema, dictencodings, compress = table_info(bytes)
+        if compress === :lz4
+            compress = LZ4_FRAME_COMPRESSOR
+        elseif compress === :zstd
+            compress = ZSTD_COMPRESSOR
+        elseif compress isa Symbol
+            throw(ArgumentError("unsupported compress keyword argument value: $compress. Valid values include `:lz4` or `:zstd`"))
+        end
+        seek(io, length(bytes) - 8) # overwrite last 8 bytes of last empty message footer
+        append(io, tbl, arrow_schema, dictencodings, compress, largelists, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks)
+    end
+
+    return file
+end
+
+function append(io::IO, source, arrow_schema, dictencodings, compress, largelists, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks)
+    sch = Ref{Tables.Schema}(arrow_schema)
+    msgs = OrderedChannel{Message}(ntasks)
+    # build messages
+    blocks = (Block[], Block[])
+    # start message writing from channel
+    threaded = ntasks > 1
+    tsk = threaded ? (Threads.@spawn for msg in msgs
+        Base.write(io, msg, blocks, sch, alignment)
+    end) : (@async for msg in msgs
+        Base.write(io, msg, blocks, sch, alignment)
+    end)
+    anyerror = Threads.Atomic{Bool}(false)
+    errorref = Ref{Any}()
+    @sync for (i, tbl) in enumerate(Tables.partitions(source))
+        if anyerror[]
+            @error "error writing arrow data on partition = $(errorref[][3])" exception=(errorref[][1], errorref[][2])
+            error("fatal error writing arrow data")
+        end
+        @debug 1 "processing table partition i = $i"
+        tbl_schema = Tables.schema(tbl)
+
+        if !is_equivalent_schema(arrow_schema, tbl_schema)
+            throw(ArgumentError("Table schema does not match existing arrow file schema"))
+        end
+
+        if threaded
+            Threads.@spawn process_partition(tbl, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
+        else
+            @async process_partition(tbl, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
+        end
+    end
+    if anyerror[]
+        @error "error writing arrow data on partition = $(errorref[][3])" exception=(errorref[][1], errorref[][2])
+        error("fatal error writing arrow data")
+    end
+    # close our message-writing channel, no further put!-ing is allowed
+    close(msgs)
+    # now wait for our message-writing task to finish writing
+    wait(tsk)
+
+    Base.write(io, Message(UInt8[], nothing, 0, true, false, Meta.Schema), blocks, sch, alignment)
+
+    return io
+end
+
+function table_info(file::String; kwargs...)
+    open(file) do io
+        table_info(io; file=true, kwargs...)
+    end
+end
+table_info(io::IO; file::Bool=false, kwargs...) = table_info(file ? Mmap.mmap(io) : Base.read(io); kwargs...)
+function table_info(bytes::Vector{UInt8}; convert::Bool=true)
+    dictencodings = Dict{Int64, DictEncoding}() # dictionary id => DictEncoding
+    names = []
+    types = []
+    compression = nothing
+    stream_format = is_stream_format(bytes)
+    for batch in BatchIterator(bytes, stream_format ? 1 : 9)
+        # store custom_metadata of batch.msg?
+        header = batch.msg.header
+        if header isa Meta.Schema
+            @debug 1 "parsing schema message"
+            # assert endianness?
+            # store custom_metadata?
+            for (i, field) in enumerate(header.fields)
+                push!(names, Symbol(field.name))
+                d = field.dictionary
+                if d === nothing
+                    push!(types, juliaeltype(field, false))
+                else
+                    push!(types, d.indexType === nothing ? Int32 : juliaeltype(field, d.indexType, false))
+                end
+            end
+        elseif header isa Meta.DictionaryBatch
+            id = header.id
+            recordbatch = header.data
+            @debug 1 "parsing dictionary batch message: id = $id, compression = $(recordbatch.compression)"
+            if recordbatch.compression !== nothing
+                compression = recordbatch.compression
+            end
+            if haskey(dictencodings, id) && header.isDelta
+                # delta
+                field = dictencoded[id]
+                values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, Int64(1), Int64(1), convert)
+                dictencoding = dictencodings[id]
+                if typeof(dictencoding.data) <: ChainedVector
+                    append!(dictencoding.data, values)
+                else
+                    A = ChainedVector([dictencoding.data, values])
+                    S = field.dictionary.indexType === nothing ? Int32 : juliaeltype(field, field.dictionary.indexType, false)
+                    dictencodings[id] = DictEncoding{eltype(A), S, typeof(A)}(id, A, field.dictionary.isOrdered, values.metadata)
+                end
+                continue
+            end
+            # new dictencoding or replace
+            field = dictencoded[id]
+            values, _, _ = build(field, field.type, batch, recordbatch, dictencodings, Int64(1), Int64(1), convert)
+            A = values
+            S = field.dictionary.indexType === nothing ? Int32 : juliaeltype(field, field.dictionary.indexType, false)
+            dictencodings[id] = DictEncoding{eltype(A), S, typeof(A)}(id, A, field.dictionary.isOrdered, values.metadata)
+            @debug 1 "parsed dictionary batch message: id=$id, data=$values\n"
+        elseif header isa Meta.RecordBatch
+            @debug 1 "parsing record batch message: compression = $(header.compression)"
+            if header.compression !== nothing
+                compression = header.compression
+            end
+        else
+            throw(ArgumentError("unsupported arrow message type: $(typeof(header))"))
+        end
+    end
+
+    compression_codec = nothing
+    if compression !== nothing
+        if compression.codec == Flatbuf.CompressionType.ZSTD
+            compression_codec = :zstd
+        elseif compression.codec == Flatbuf.CompressionType.LZ4_FRAME
+            compression_codec = :lz4
+        else
+            throw(ArgumentError("unsupported compression codec: $(compression.codec)"))
+        end
+    end
+    Tables.Schema(names, types), dictencodings, compression_codec
+end
+
+function footer_offset(bytes::Vector{UInt8})
+    magic_len = length(FILE_FORMAT_MAGIC_BYTES)
+    startoffset = length(bytes) - magic_len - sizeof(Int32) + 1
+    endoffset = length(bytes) - magic_len
+
+    read(IOBuffer(bytes[startoffset:endoffset]), Int32) + magic_len + sizeof(Int32)
+end
+
+function is_stream_format(file::String)
+    open(file) do io
+        is_stream_format(io, true)
+    end
+end
+is_stream_format(io::IO, file::Bool=false) = is_stream_format(file ? Mmap.mmap(io) : Base.read(io))
+function is_stream_format(bytes::Vector{UInt8})
+    len = length(bytes)
+    off = 1
+    if len > 24 &&
+        _startswith(bytes, off, FILE_FORMAT_MAGIC_BYTES) &&
+        _endswith(bytes, off + len - 1, FILE_FORMAT_MAGIC_BYTES)
+        return false
+    else
+        return true
+    end
+end
+
+function convert_to_stream_format(file::String; kwargs...)
+    mktemp() do path, io
+        convert_to_stream_format(file, io; kwargs...)
+        close(io)
+        cp(path, file; force=true)
+    end
+    nothing
+end
+function convert_to_stream_format(source::String, dest::String; kwargs...)
+    open(dest, "w") do destio
+        convert_to_stream_format(source, destio; kwargs...)
+    end
+    nothing
+end
+function convert_to_stream_format(source::String, destio::IO; kwargs...)
+    open(source) do sourceio
+        convert_to_stream_format(sourceio, destio; kwargs...)
+    end
+    nothing
+end
+function convert_to_stream_format(sourceio::IO, destio::IO; kwargs...)
+    write(destio, Stream(sourceio); file=false, kwargs...)
+    nothing
+end
+
+function is_equivalent_schema(sch1::Tables.Schema, sch2::Tables.Schema)
+    (sch1.names == sch2.names) || (return false)
+    for (t1,t2) in zip(sch1.types, sch2.types)
+        (t1 === t2) || (return false)
+    end
+    true
+end

--- a/test/arrowjson.jl
+++ b/test/arrowjson.jl
@@ -559,7 +559,7 @@ function DataFile(source)
     dictencodings = Dict{String, Tuple{Base.Type, DictEncoding}}()
     dictid = Ref(0)
     for (i, tbl1) in Tables.partitions(source)
-        tbl = Arrow.toarrowtable(tbl1)
+        tbl = Arrow.toarrowtable(Table.columns(tbl1))
         if i == 1
             sch = Tables.schema(tbl)
             for (nm, T, col) in zip(sch.names, sch.types, Tables.Columns(tbl))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,6 +18,7 @@ using Test, Arrow, Tables, Dates, PooledArrays, TimeZones, UUIDs, CategoricalArr
 
 include(joinpath(dirname(pathof(Arrow)), "ArrowTypes/test/tests.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/testtables.jl"))
+include(joinpath(dirname(pathof(Arrow)), "../test/testappend.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/integrationtest.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/dates.jl"))
 
@@ -40,6 +41,12 @@ for case in testtables
 end
 
 end # @testset "table roundtrips"
+
+@testset "table append" begin
+
+    testappend()
+
+end # @testset "table append"
 
 @testset "arrow json integration tests" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,15 @@ end # @testset "table roundtrips"
 
 @testset "table append" begin
 
-    testappend()
+    for case in testtables
+        testappend(case...)
+    end
+
+    testappend_partitions()
+
+    for compression_option in (:lz4, :zstd)
+        testappend_compression(compression_option)
+    end
 
 end # @testset "table append"
 

--- a/test/testappend.jl
+++ b/test/testappend.jl
@@ -1,0 +1,54 @@
+function testappend()
+    mktempdir() do path
+        testdata = (col1=Int64[1,2,3,4,5,6,7,8,9,10],)
+        file1 = joinpath(path, "table1.arrow")
+        file2 = joinpath(path, "table2.arrow")
+        open(file1, "w") do io
+            Arrow.write(io, testdata; file=false)
+        end
+        open(file2, "w") do io
+            Arrow.write(io, testdata; file=false)
+        end
+
+        # start
+        # arrow_table1: 1 partition, 10 rows
+        # arrow_table2: 1 partition, 10 rows
+        arrow_table1 = Arrow.Table(file1)
+        arrow_table2 = Arrow.Table(file2)
+        @test length(Tables.columns(arrow_table1)[1]) == 10
+        @test length(Tables.columns(arrow_table2)[1]) == 10
+
+        Arrow.append(file1, arrow_table2)
+        arrow_table1 = Arrow.Table(file1)
+        # now
+        # arrow_table1: 2 partitions, 20 rows
+        # arrow_table2: 1 partition, 10 rows
+
+        @test Tables.schema(arrow_table1) == Tables.schema(arrow_table2)
+        @test length(Tables.columns(arrow_table1)[1]) == 20
+        @test length(Tables.columns(arrow_table2)[1]) == 10
+        @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == 2 * length(collect(Tables.partitions(Arrow.Stream(file2))))
+
+        Arrow.append(file2, arrow_table1)
+        arrow_table2 = Arrow.Table(file2)
+        # now
+        # arrow_table1: 2 partitions, 20 rows
+        # arrow_table2: 2 partitions, 30 rows (both partitions of table1 are appended as single partition)
+
+        @test Tables.schema(arrow_table1) == Tables.schema(arrow_table2)
+        @test length(Tables.columns(arrow_table1)[1]) == 20
+        @test length(Tables.columns(arrow_table2)[1]) == 30
+        @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == length(collect(Tables.partitions(Arrow.Stream(file2))))
+
+        Arrow.append(file1, Arrow.Stream(file2))
+        arrow_table1 = Arrow.Table(file1)
+        # now
+        # arrow_table1: 4 partitions, 50 rows (partitions of file2 stream are appended without being merged)
+        # arrow_table2: 2 partitions, 30 rows
+
+        @test Tables.schema(arrow_table1) == Tables.schema(arrow_table2)
+        @test length(Tables.columns(arrow_table1)[1]) == 50
+        @test length(Tables.columns(arrow_table2)[1]) == 30
+        @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == 2 * length(collect(Tables.partitions(Arrow.Stream(file2))))
+    end
+end

--- a/test/testappend.jl
+++ b/test/testappend.jl
@@ -27,7 +27,8 @@ function testappend_compression(compression_option)
         open(file1, "w") do io
             Arrow.write(io, testdata; file=false, compress=compression_option)
         end
-        schema, compression = open(Arrow.table_info, file1)
+        isstream, schema, compression = open(Arrow.stream_properties, file1)
+        @test isstream
         @test compression == compression_option
 
         open(file2, "w") do io
@@ -38,7 +39,8 @@ function testappend_compression(compression_option)
         arrow_table2 |> Arrow.append(file1)
         arrow_table1 = Arrow.Table(file1)
 
-        schema, compression = open(Arrow.table_info, file1)
+        isstream, schema, compression = open(Arrow.stream_properties, file1)
+        @test isstream
         @test compression == compression_option
 
         @test length(Tables.columns(arrow_table1)[1]) == 20
@@ -55,7 +57,8 @@ function testappend_partitions()
             Arrow.write(io, testdata; file=false)
         end
         arrow_table1 = Arrow.Table(file1)
-        schema, compression = open(Arrow.table_info, file1)
+        isstream, schema, compression = open(Arrow.stream_properties, file1)
+        @test isstream
         @test compression === nothing
         @test schema.names == (:col1,)
         @test schema.types == (Int64,)

--- a/test/testappend.jl
+++ b/test/testappend.jl
@@ -27,7 +27,7 @@ function testappend_compression(compression_option)
         open(file1, "w") do io
             Arrow.write(io, testdata; file=false, compress=compression_option)
         end
-        schema, compression = Arrow.table_info(file1)
+        schema, compression = open(Arrow.table_info, file1)
         @test compression == compression_option
 
         open(file2, "w") do io
@@ -38,7 +38,7 @@ function testappend_compression(compression_option)
         arrow_table2 |> Arrow.append(file1)
         arrow_table1 = Arrow.Table(file1)
 
-        schema, compression = Arrow.table_info(file1)
+        schema, compression = open(Arrow.table_info, file1)
         @test compression == compression_option
 
         @test length(Tables.columns(arrow_table1)[1]) == 20
@@ -55,7 +55,7 @@ function testappend_partitions()
             Arrow.write(io, testdata; file=false)
         end
         arrow_table1 = Arrow.Table(file1)
-        schema, compression = Arrow.table_info(file1)
+        schema, compression = open(Arrow.table_info, file1)
         @test compression === nothing
         @test schema.names == (:col1,)
         @test schema.types == (Int64,)

--- a/test/testappend.jl
+++ b/test/testappend.jl
@@ -1,4 +1,52 @@
-function testappend()
+function testappend(nm, t, writekw, readkw, extratests)
+    println("testing append: $nm")
+    io = Arrow.tobuffer(t; writekw...)
+    bytes = read(io)
+    mktemp() do path, io
+        write(io, bytes)
+        close(io)
+
+        t1 = Arrow.Table(read(path); readkw...)
+        f1 = first(Tables.columns(t1))
+        Arrow.append(path, t1; writekw..., readkw...)
+        nparts = 0
+        for t2 in Arrow.Stream(path)
+            @test isequal(f1, first(Tables.columns(t2)))
+            nparts += 1
+        end
+        @test nparts == 2
+    end
+end
+
+function testappend_compression(compression_option)
+    mktempdir() do path
+        testdata = (col1=Int64[1,2,3,4,5,6,7,8,9,10],)
+        file1 = joinpath(path, "table1.arrow")
+        file2 = joinpath(path, "table2.arrow")
+
+        open(file1, "w") do io
+            Arrow.write(io, testdata; file=false, compress=compression_option)
+        end
+        schema, compression = Arrow.table_info(file1)
+        @test compression == compression_option
+
+        open(file2, "w") do io
+            Arrow.write(io, testdata; file=false)
+        end
+
+        arrow_table2 = Arrow.Table(file2)
+        arrow_table2 |> Arrow.append(file1)
+        arrow_table1 = Arrow.Table(file1)
+
+        schema, compression = Arrow.table_info(file1)
+        @test compression == compression_option
+
+        @test length(Tables.columns(arrow_table1)[1]) == 20
+        @test length(Tables.columns(arrow_table2)[1]) == 10
+    end
+end
+
+function testappend_partitions()
     mktempdir() do path
         testdata = (col1=Int64[1,2,3,4,5,6,7,8,9,10],)
         file1 = joinpath(path, "table1.arrow")
@@ -6,6 +54,26 @@ function testappend()
         open(file1, "w") do io
             Arrow.write(io, testdata; file=false)
         end
+        arrow_table1 = Arrow.Table(file1)
+        schema, compression = Arrow.table_info(file1)
+        @test compression === nothing
+        @test schema.names == (:col1,)
+        @test schema.types == (Int64,)
+
+        # can only append to arrow stream
+        open(file2, "w") do io
+            Arrow.write(io, testdata; file=true)
+        end
+        @test_throws ArgumentError Arrow.append(file2, arrow_table1)
+
+        # schema must match
+        testdata2 = (col2=Int64[1,2,3,4,5,6,7,8,9,10],)
+        open(file2, "w") do io
+            Arrow.write(io, testdata2; file=false)
+        end
+        @test_throws ArgumentError Arrow.append(file2, arrow_table1)
+
+        # recreate file2 in arrow format with correct schema
         open(file2, "w") do io
             Arrow.write(io, testdata; file=false)
         end
@@ -13,12 +81,12 @@ function testappend()
         # start
         # arrow_table1: 1 partition, 10 rows
         # arrow_table2: 1 partition, 10 rows
-        arrow_table1 = Arrow.Table(file1)
         arrow_table2 = Arrow.Table(file2)
         @test length(Tables.columns(arrow_table1)[1]) == 10
         @test length(Tables.columns(arrow_table2)[1]) == 10
 
-        Arrow.append(file1, arrow_table2)
+        @test_throws ArgumentError Arrow.append(file1, arrow_table2; ntasks = -1)
+        arrow_table2 |> Arrow.append(file1)
         arrow_table1 = Arrow.Table(file1)
         # now
         # arrow_table1: 2 partitions, 20 rows
@@ -29,7 +97,7 @@ function testappend()
         @test length(Tables.columns(arrow_table2)[1]) == 10
         @test length(collect(Tables.partitions(Arrow.Stream(file1)))) == 2 * length(collect(Tables.partitions(Arrow.Stream(file2))))
 
-        Arrow.append(file2, arrow_table1)
+        Arrow.append(file2, arrow_table1; ntasks=1) # append with single task
         arrow_table2 = Arrow.Table(file2)
         # now
         # arrow_table1: 2 partitions, 20 rows


### PR DESCRIPTION
This adds a method to `append` partitions to existing arrow files. Partitiions to append to are supplied in the form of any [Tables.jl](https://github.com/JuliaData/Tables.jl)-compatible table.

Multiple record batches will be written based on the number of `Tables.partitions(tbl)` that are provided.

Each partition being appended must have the same `Tables.Schema` as the destination arrow file that is being appended to.

Other parameters that `append` accepts are similar to what `write` accepts.