### PR TITLE
Tweak promoteunion to always avoid abstract types

### DIFF
--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -305,7 +305,7 @@ default(::Type{NamedTuple{names, types}}) where {names, types} = NamedTuple{name
 
 function promoteunion(T, S)
     new = promote_type(T, S)
-    return new === Any ? Union{T, S} : new
+    return isabstracttype(new) ? Union{T, S} : new
 end
 
 # lazily call toarrow(x) on getindex for each x in data


### PR DESCRIPTION
This makes the 2nd `concretecheck` unnecessary in the `ToArrow`
constructor, but we'll leave it for now as a type of assert. This came
from a discussion with @iamed on slack, where it was pointed out that
values always have a concrete type at runtime (yay Julia!), so we should
_always_ be able to get a `Union{...}` of concrete types. This could
potentially get crazy if someone has, like, thousands of unique concrete
types in a single array, but I guess we'll cross that bridge when we
come to it.