### PR TITLE
Don't store table metadata globally

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -159,11 +159,11 @@ struct Table <: Tables.AbstractColumns
     columns::Vector{AbstractVector}
     lookup::Dict{Symbol, AbstractVector}
     schema::Ref{Meta.Schema}
-    metadata::Ref{Any}
+    metadata::Ref{Dict{String, String}}
 end
 
-Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Any}())
-Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Any}())
+Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Dict{String, String}}())
+Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Dict{String, String}}())
 
 names(t::Table) = getfield(t, :names)
 types(t::Table) = getfield(t, :types)
@@ -275,7 +275,7 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
     end
     meta = sch !== nothing ? sch.custom_metadata : nothing
     if meta !== nothing
-        getfield(t, :metadata)[] = meta
+        getfield(t, :metadata)[] = Dict(x.key=>x.value for x in meta)
     end
     return t
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -163,6 +163,7 @@ struct Table <: Tables.AbstractColumns
 end
 
 Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), nothing)
+Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, nothing)
 
 names(t::Table) = getfield(t, :names)
 types(t::Table) = getfield(t, :types)

--- a/src/table.jl
+++ b/src/table.jl
@@ -159,15 +159,17 @@ struct Table <: Tables.AbstractColumns
     columns::Vector{AbstractVector}
     lookup::Dict{Symbol, AbstractVector}
     schema::Ref{Meta.Schema}
+    metadata::Union{Nothing, Dict{String, String}}
 end
 
-Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}())
+Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), nothing)
 
 names(t::Table) = getfield(t, :names)
 types(t::Table) = getfield(t, :types)
 columns(t::Table) = getfield(t, :columns)
 lookup(t::Table) = getfield(t, :lookup)
 schema(t::Table) = getfield(t, :schema)
+getmetadata(t::Table) = getfield(t, :metadata)
 
 Tables.istable(::Table) = true
 Tables.columnaccess(::Table) = true
@@ -272,7 +274,7 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
     end
     meta = sch !== nothing ? sch.custom_metadata : nothing
     if meta !== nothing
-        setmetadata!(t, Dict(String(kv.key) => String(kv.value) for kv in meta))
+        setfield!(t, :metadata, meta)
     end
     return t
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -162,8 +162,8 @@ struct Table <: Tables.AbstractColumns
     metadata::Ref{Dict{String, String}}
 end
 
-Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Dict{String, String}()})
-Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Dict{String, String}()})
+Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Dict{String, String}}())
+Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Dict{String, String}}())
 
 names(t::Table) = getfield(t, :names)
 types(t::Table) = getfield(t, :types)

--- a/src/table.jl
+++ b/src/table.jl
@@ -159,18 +159,18 @@ struct Table <: Tables.AbstractColumns
     columns::Vector{AbstractVector}
     lookup::Dict{Symbol, AbstractVector}
     schema::Ref{Meta.Schema}
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Ref{Dict{String, String}}
 end
 
-Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), nothing)
-Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, nothing)
+Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Dict{String, String}()})
+Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Dict{String, String}()})
 
 names(t::Table) = getfield(t, :names)
 types(t::Table) = getfield(t, :types)
 columns(t::Table) = getfield(t, :columns)
 lookup(t::Table) = getfield(t, :lookup)
 schema(t::Table) = getfield(t, :schema)
-getmetadata(t::Table) = getfield(t, :metadata)
+getmetadata(t::Table) = isdefined(getfield(t, :metadata), :x) ? getfield(t, :metadata)[] : nothing
 
 Tables.istable(::Table) = true
 Tables.columnaccess(::Table) = true
@@ -275,7 +275,7 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
     end
     meta = sch !== nothing ? sch.custom_metadata : nothing
     if meta !== nothing
-        setfield!(t, :metadata, meta)
+        getfield(t, :metadata)[] = meta
     end
     return t
 end

--- a/src/table.jl
+++ b/src/table.jl
@@ -159,11 +159,11 @@ struct Table <: Tables.AbstractColumns
     columns::Vector{AbstractVector}
     lookup::Dict{Symbol, AbstractVector}
     schema::Ref{Meta.Schema}
-    metadata::Ref{Dict{String, String}}
+    metadata::Ref{Any}
 end
 
-Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Dict{String, String}}())
-Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Dict{String, String}}())
+Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Any}())
+Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Any}())
 
 names(t::Table) = getfield(t, :names)
 types(t::Table) = getfield(t, :types)


### PR DESCRIPTION
Fixes #90. There's no need to store table metadata globally when we can
just store it in the Table type itself and overload the `getmetadata`.
This should avoid metadata bloat in the global store.