### PR TITLE
document guarantee that `getmetadata` returns alias not copy

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -31,11 +31,16 @@ end
 """
     Arrow.getmetadata(x) => Dict{String, String}
 
-Retrieve any metadata (as a `Dict{String, String}`) attached to an object.
+Retrieve any metadata (as a `Dict{String, String}`) attached to `x`.
 
 Metadata may be attached to any object via [`Arrow.setmetadata!`](@ref),
 or deserialized via the arrow format directly (the format allows attaching metadata
 to table, column, and other objects).
+
+Note that this function's return value directly aliases `x`'s attached metadata 
+(i.e. is not a copy of the underlying storage). Any method author that overloads 
+this function should preserve this behavior so that downstream callers can rely
+on this behavior in generic code.
 """
 getmetadata(x, default=nothing) = get(OBJ_METADATA, x, default)
 


### PR DESCRIPTION
ref https://github.com/JuliaData/Arrow.jl/issues/90#issuecomment-813040097

I'm relying on this currently undocumented behavior in downstream code that looks like:

```jl
function assign_to_table_metadata!(table, pairs)
    m = Arrow.getmetadata(table)
    if !(m isa Dict)
        m = Dict{String,String}()
        Arrow.setmetadata!(table, m)
    end
    for (k, v) in pairs
        m[k] = v
    end
    return m
end
```

Seems like there's not much harm in explicitly documenting this assumption so that I can say the above code is "generic" 😁 