### PR TITLE
add missing setmedata! method for Arrow.Table

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -171,6 +171,7 @@ columns(t::Table) = getfield(t, :columns)
 lookup(t::Table) = getfield(t, :lookup)
 schema(t::Table) = getfield(t, :schema)
 getmetadata(t::Table) = isdefined(getfield(t, :metadata), :x) ? getfield(t, :metadata)[] : nothing
+setmetadata!(t::Table, m::Dict{String, String}) = (setindex!(getfield(t, :metadata), m); nothing)
 
 Tables.istable(::Table) = true
 Tables.columnaccess(::Table) = true
@@ -245,7 +246,7 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
                 else
                     A = ChainedVector([dictencoding.data, values])
                     S = field.dictionary.indexType === nothing ? Int32 : juliaeltype(field, field.dictionary.indexType, false)
-                    dictencodings[id] = DictEncoding{eltype(A), S, typeof(A)}(id, A, field.dictionary.isOrdered, values.metadata)        
+                    dictencodings[id] = DictEncoding{eltype(A), S, typeof(A)}(id, A, field.dictionary.isOrdered, values.metadata)
                 end
                 continue
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -276,6 +276,12 @@ ArrowTypes.JuliaType(::Val{:CustomStruct2}, S, meta) = CustomStruct2{Symbol(meta
 tbl = Arrow.Table(Arrow.tobuffer(t))
 @test eltype(tbl.col1) == CustomStruct2{:hey}
 
+# 170
+tbl = Arrow.Table(Arrow.tobuffer((x = [1,2,3],)))
+m = Dict("a" => "b")
+Arrow.setmetadata!(tbl, m)
+@test Arrow.getmetadata(tbl) === m
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
I'm not sure if I'm misinterpreting, but it seems like #165 also needed a corresponding `setmetadata!` for the specialization to behave as expected - otherwise the test added by this PR fails (and it seems like such a test should pass 😁)