### PR TITLE
use actual deprecation for `registertype!`

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -373,7 +373,8 @@ function extensiontype(f, meta)
 end
 
 function registertype!(juliatype::Type, arrowtype::Type, arrowname::String=string("JuliaLang.", string(juliatype)))
-    @warn "Arrow.ArrowTypes.registertype! is deprecated in favor of defining `ArrowTypes.ArrowType`, `ArrowTypes.arrowname`, and `ArrowTypes.JuliaType`; see their docs for more information on how to migrate"
+    msg = "Arrow.ArrowTypes.registertype! is deprecated in favor of defining `ArrowTypes.ArrowType`, `ArrowTypes.arrowname`, and `ArrowTypes.JuliaType`; see their docs for more information on how to migrate"
+    Base.depwarn(msg, :registertype!)
     # TODO: validate that juliatype isn't already default arrow type
     JULIA_TO_ARROW_TYPE_MAPPING[juliatype] = (arrowname, arrowtype)
     ARROW_TO_JULIA_TYPE_MAPPING[arrowname] = (juliatype, arrowtype)

--- a/src/arrowtypes.jl
+++ b/src/arrowtypes.jl
@@ -372,7 +372,8 @@ function extensiontype(f, meta)
 end
 
 function registertype!(juliatype::Type, arrowtype::Type, arrowname::String=string("JuliaLang.", string(juliatype)))
-    @warn "Arrow.ArrowTypes.registertype! is deprecated in favor of defining `ArrowTypes.ArrowType`, `ArrowTypes.arrowname`, and `ArrowTypes.JuliaType`; see their docs for more information on how to migrate"
+    msg = "Arrow.ArrowTypes.registertype! is deprecated in favor of defining `ArrowTypes.ArrowType`, `ArrowTypes.arrowname`, and `ArrowTypes.JuliaType`; see their docs for more information on how to migrate"
+    Base.depwarn(msg, :registertype!)
     # TODO: validate that juliatype isn't already default arrow type
     JULIA_TO_ARROW_TYPE_MAPPING[juliatype] = (arrowname, arrowtype)
     ARROW_TO_JULIA_TYPE_MAPPING[arrowname] = (juliatype, arrowtype)


### PR DESCRIPTION
This means if you aren't running tests or otherwise start julia with `--depwarn=yes` then you don't see the warning, and moreover you only see the warning once. Motivated by me seeing this warning three times when just calling `using X` from some downstream package that doesn't even call `registertype!` itself!

If you do want it to be visible to all users to try to push more for users to update, then another option is to use `@warn` but with `maxlog=1` which should emit the warning only once.