### PR TITLE
Warn when converting Arrow.Timestamps to Dates.DateTime or ZonedDateTime

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -282,6 +282,13 @@ m = Dict("a" => "b")
 Arrow.setmetadata!(tbl, m)
 @test Arrow.getmetadata(tbl) === m
 
+# 166
+t = (
+    col1=[zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.NANOSECOND, nothing})],
+)
+tbl = Arrow.Table(Arrow.tobuffer(t))
+@test tbl.col1[1] == Dates.DateTime(1970)
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
Fixes #166. The problem OP saw in the original issue was that we didn't
have a proper `ArrowTypes.fromarrow` method defined for `Dates.DateTime`
from `Arrow.Timestamp` with nanosecond precision, which is accurate in
one sense because `Dates.DateTime` only supports up to millisecond
precision. But better than just erroring when trying to access these
values later, we now do the conversion anyway, which may be lossy, and
issue a warning about the potentially lossy conversion. If > millisecond
precision is needed, then users should pass `convert=false` and operate
on the `Arrow.Timestamp` values directly for now.