### PR TITLE
Fix slight perf hit when checking validity bitmap

### DIFF
--- a/src/arraytypes/arraytypes.jl
+++ b/src/arraytypes/arraytypes.jl
@@ -164,7 +164,7 @@ end
     #   2) parent array is also empty, so "all" elements are valid
     p.nc == 0 && return true
     # translate element index to bitpacked byte index
-    a, b = fldmod1(i, 8)
+    a, b = divrem(i-1, 8) .+ (1,1)
     @inbounds byte = p.bytes[p.pos + a - 1]
     # check individual bit of byte
     return getbit(byte, b)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -54,7 +54,7 @@ function writearray(io::IO, ::Type{T}, col) where {T}
     return n
 end
 
-getbit(v::UInt8, n::Integer) = Bool((v & 0x02^(n - 1)) >> (n - 1))
+getbit(v::UInt8, n::Integer) = (v & (1 << (n - 1))) > 0x00
 
 function setbit(v::UInt8, b::Bool, n::Integer)
     if b


### PR DESCRIPTION
Fixes #131. Dip me in mustard and call me a hotdog, cuz I can't tell
how/why `divrem(i - 1, 8) .+ (1, 1)` ends up being ~30% faster than
`fldmod1(i, 8)`. It'd probably be worth looking into it more, but it
works for now. The divrem code is @expandingman 's code from his
arrow/feather code.