### PR TITLE
import DataAPI when adding methods

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -42,8 +42,8 @@ See docs for official Arrow.jl API with the [User Manual](@ref) and reference do
 module Arrow
 
 using Mmap
-import Dates
-using DataAPI, Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd, TimeZones, BitIntegers
+import DataAPI, Dates
+using Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd, TimeZones, BitIntegers
 
 export ArrowTypes
 


### PR DESCRIPTION
I believe the change to `import DataAPI` is necessary so that the methods for `DataAPI.levels`, etc. defined in `src/arraytypes/dictencoding.jl` are visible outside the module.