### PR TITLE
Add global metadata lock to ensure thread safety of global metadata

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -106,6 +106,7 @@ function __init__()
         CodecLz4.TranscodingStreams.initialize(lz4)
         push!(LZ4_FRAME_COMPRESSOR, lz4)
     end
+    OBJ_METADATA_LOCK[] = ReentrantLock()
     return
 end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -25,7 +25,7 @@ Metadata attached to a table or column will be serialized when written
 as a stream or file.
 """
 function setmetadata!(x, meta::Dict{String, String})
-    lock(OBJ_METADATA_LOCK) do
+    lock(OBJ_METADATA_LOCK[]) do
         OBJ_METADATA[x] = meta
     end
     return
@@ -45,7 +45,7 @@ Note that this function's return value directly aliases `x`'s attached metadata
 this function should preserve this behavior so that downstream callers can rely
 on this behavior in generic code.
 """
-getmetadata(x, default=nothing) = lock(() -> get(OBJ_METADATA, x, default), OBJ_METADATA_LOCK)
+getmetadata(x, default=nothing) = lock(() -> get(OBJ_METADATA, x, default), OBJ_METADATA_LOCK[])
 
 const DEFAULT_MAX_DEPTH = 6
 


### PR DESCRIPTION
store

Follow up to #90, based on discussions in that issue.