### PR TITLE
Handle empty tuple

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -261,10 +261,12 @@ fromarrow(::Type{NamedTuple{names, types}}, x::NamedTuple{names, types}) where {
 fromarrow(::Type{T}, x::NamedTuple) where {T} = fromarrow(T, Tuple(x)...)
 
 ArrowKind(::Type{<:Tuple}) = StructKind()
+ArrowKind(::Type{Tuple{}}) = StructKind()
 const TUPLE = Symbol("JuliaLang.Tuple")
 # needed to disambiguate the FixedSizeList case for NTuple
 arrowname(::Type{NTuple{N, T}}) where {N, T} = EMPTY_SYMBOL
 arrowname(::Type{T}) where {T <: Tuple} = TUPLE
+arrowname(::Type{Tuple{}}) = TUPLE
 JuliaType(::Val{TUPLE}, ::Type{NamedTuple{names, types}}) where {names, types <: Tuple} = types
 fromarrow(::Type{T}, x::NamedTuple) where {T <: Tuple} = Tuple(x)
 

--- a/src/ArrowTypes/test/tests.jl
+++ b/src/ArrowTypes/test/tests.jl
@@ -92,7 +92,9 @@ nt = (id=1, name="bob")
 @test ArrowTypes.fromarrow(typeof(nt), nt) === nt
 @test ArrowTypes.fromarrow(Person, nt) == Person(1, "bob")
 @test ArrowTypes.ArrowKind(Tuple) == ArrowTypes.StructKind()
+@test ArrowTypes.ArrowKind(Tuple{}) == ArrowTypes.StructKind()
 @test ArrowTypes.arrowname(Tuple{Int, String}) == ArrowTypes.TUPLE
+@test ArrowTypes.arrowname(Tuple{}) == ArrowTypes.TUPLE
 @test ArrowTypes.JuliaType(Val(ArrowTypes.TUPLE), NamedTuple{(Symbol("1"), Symbol("2")), Tuple{Int, String}}) == Tuple{Int, String}
 @test ArrowTypes.fromarrow(Tuple{Int, String}, nt) == (1, "bob")
 

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -79,6 +79,16 @@ testtables = [
     nothing
   ),
   (
+    "empty list types",
+    (
+      col1=[[]],
+      col2=[()],
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
     "unions",
     (
       col1=Arrow.DenseUnionVector( Union{Int64, Float64, Missing}[1, 2.0, 3, 4.0, missing]),


### PR DESCRIPTION
Fixes https://github.com/JuliaData/Arrow.jl/issues/200:

```julia
julia> using Arrow

julia> table = [(; version = v"1")]
1-element Vector{NamedTuple{(:version,), Tuple{VersionNumber}}}:
 (version = v"1.0.0",)

julia> io = IOBuffer();

julia> Arrow.write(io, table)
IOBuffer(data=UInt8[...], readable=true, writable=true, seekable=true, append=false, size=1016, maxsize=Inf, ptr=1017, mark=-1)

julia> t = Arrow.Table(seekstart(io))
Arrow.Table with 1 rows, 1 columns, and schema:
 :version  NamedTuple{(:major, :minor, :patch, :prerelease, :build), Tuple{UInt32, UInt32, UInt32, Tuple{}, Tuple{}}}

julia> t.version
1-element Arrow.Struct{NamedTuple{(:major, :minor, :patch, :prerelease, :build), Tuple{UInt32, UInt32, UInt32, Tuple{}, Tuple{}}}, Tuple{Arrow.Primitive{UInt32, Vector{UInt32}}, Arrow.Primitive{UInt32, Vector{UInt32}}, Arrow.Primitive{UInt32, Vector{UInt32}}, Arrow.Struct{Tuple{}, Tuple{}}, Arrow.Struct{Tuple{}, Tuple{}}}}:
 (major = 0x00000001, minor = 0x00000000, patch = 0x00000000, prerelease = (), build = ())
```