### PR TITLE
Support `VersionNumber`

### DIFF
--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -270,6 +270,16 @@ arrowname(::Type{Tuple{}}) = TUPLE
 JuliaType(::Val{TUPLE}, ::Type{NamedTuple{names, types}}) where {names, types <: Tuple} = types
 fromarrow(::Type{T}, x::NamedTuple) where {T <: Tuple} = Tuple(x)
 
+# VersionNumber
+const VERSION_NUMBER = Symbol("JuliaLang.VersionNumber")
+ArrowKind(::Type{VersionNumber}) = StructKind()
+arrowname(::Type{VersionNumber}) = VERSION_NUMBER
+JuliaType(::Val{VERSION_NUMBER}) = VersionNumber
+
+function fromarrow(::Type{VersionNumber}, v::NamedTuple)
+    VersionNumber(v.major, v.minor, v.patch, v.prerelease, v.build)
+end
+
 "MapKind data are stored similarly to ListKind, where elements are flattened, and a 2nd offsets buffer contains the individual list element length data"
 struct MapKind <: ArrowKind end
 

--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -261,10 +261,12 @@ fromarrow(::Type{NamedTuple{names, types}}, x::NamedTuple{names, types}) where {
 fromarrow(::Type{T}, x::NamedTuple) where {T} = fromarrow(T, Tuple(x)...)
 
 ArrowKind(::Type{<:Tuple}) = StructKind()
+ArrowKind(::Type{Tuple{}}) = StructKind()
 const TUPLE = Symbol("JuliaLang.Tuple")
 # needed to disambiguate the FixedSizeList case for NTuple
 arrowname(::Type{NTuple{N, T}}) where {N, T} = EMPTY_SYMBOL
 arrowname(::Type{T}) where {T <: Tuple} = TUPLE
+arrowname(::Type{Tuple{}}) = TUPLE
 JuliaType(::Val{TUPLE}, ::Type{NamedTuple{names, types}}) where {names, types <: Tuple} = types
 fromarrow(::Type{T}, x::NamedTuple) where {T <: Tuple} = Tuple(x)
 

--- a/src/ArrowTypes/test/tests.jl
+++ b/src/ArrowTypes/test/tests.jl
@@ -98,6 +98,13 @@ nt = (id=1, name="bob")
 @test ArrowTypes.JuliaType(Val(ArrowTypes.TUPLE), NamedTuple{(Symbol("1"), Symbol("2")), Tuple{Int, String}}) == Tuple{Int, String}
 @test ArrowTypes.fromarrow(Tuple{Int, String}, nt) == (1, "bob")
 
+v = v"1"
+v_nt = (major=1, minor=0, patch=0, prerelease=(), build=())
+@test ArrowTypes.ArrowKind(VersionNumber) == ArrowTypes.StructKind()
+@test ArrowTypes.arrowname(VersionNumber) == ArrowTypes.VERSION_NUMBER
+@test ArrowTypes.JuliaType(Val(ArrowTypes.VERSION_NUMBER)) == VersionNumber
+@test ArrowTypes.fromarrow(typeof(v), v_nt) == v
+
 @test ArrowTypes.ArrowKind(Dict{String, Int}) == ArrowTypes.MapKind()
 @test ArrowTypes.ArrowKind(Union{String, Int}) == ArrowTypes.UnionKind()
 

--- a/src/ArrowTypes/test/tests.jl
+++ b/src/ArrowTypes/test/tests.jl
@@ -92,7 +92,9 @@ nt = (id=1, name="bob")
 @test ArrowTypes.fromarrow(typeof(nt), nt) === nt
 @test ArrowTypes.fromarrow(Person, nt) == Person(1, "bob")
 @test ArrowTypes.ArrowKind(Tuple) == ArrowTypes.StructKind()
+@test ArrowTypes.ArrowKind(Tuple{}) == ArrowTypes.StructKind()
 @test ArrowTypes.arrowname(Tuple{Int, String}) == ArrowTypes.TUPLE
+@test ArrowTypes.arrowname(Tuple{}) == ArrowTypes.TUPLE
 @test ArrowTypes.JuliaType(Val(ArrowTypes.TUPLE), NamedTuple{(Symbol("1"), Symbol("2")), Tuple{Int, String}}) == Tuple{Int, String}
 @test ArrowTypes.fromarrow(Tuple{Int, String}, nt) == (1, "bob")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,7 +347,7 @@ tbl = Arrow.Table(Arrow.tobuffer(t))
         col1=[v"1"],
     )
     tbl = Arrow.Table(Arrow.tobuffer(t))
-    @test eltype(tbl.col1) == Vector{VersionNumber}
+    @test eltype(tbl.col1) == VersionNumber
 end
 
 end # @testset "misc"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -341,6 +341,15 @@ t = (
 tbl = Arrow.Table(Arrow.tobuffer(t))
 @test eltype(tbl.col1) == Vector{String}
 
+# 200
+@testset "VersionNumber" begin
+    t = (
+        col1=[v"1"],
+    )
+    tbl = Arrow.Table(Arrow.tobuffer(t))
+    @test eltype(tbl.col1) == Vector{VersionNumber}
+end
+
 end # @testset "misc"
 
 end

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -79,6 +79,16 @@ testtables = [
     nothing
   ),
   (
+    "empty list types",
+    (
+      col1=[[]],
+      col2=[()],
+    ),
+    NamedTuple(),
+    NamedTuple(),
+    nothing
+  ),
+  (
     "unions",
     (
       col1=Arrow.DenseUnionVector( Union{Int64, Float64, Missing}[1, 2.0, 3, 4.0, missing]),


### PR DESCRIPTION
Fixes #200 by adding round-trip support for `VersionNumber`. Requires #201.