### PR TITLE
support Date with type parameter ms

### DIFF
--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -293,6 +293,7 @@ const DATETIME_SYMBOL = Symbol("JuliaLang.DateTime")
 ArrowTypes.arrowname(::Type{Dates.DateTime}) = DATETIME_SYMBOL
 ArrowTypes.JuliaType(::Val{DATETIME_SYMBOL}, S) = Dates.DateTime
 ArrowTypes.fromarrow(::Type{Dates.DateTime}, x::Timestamp) = convert(Dates.DateTime, x)
+ArrowTypes.fromarrow(::Type{Dates.DateTime}, x::Date{Meta.DateUnit.MILLISECOND, Int64}) = convert(Dates.DateTime, x)
 ArrowTypes.default(::Type{Dates.DateTime}) = Dates.DateTime(1,1,1,1,1,1)
 
 ArrowTypes.ArrowType(::Type{ZonedDateTime}) = Timestamp

--- a/test/testtables.jl
+++ b/test/testtables.jl
@@ -59,6 +59,7 @@ testtables = [
       col17=[zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), zero(Arrow.Timestamp{Arrow.Meta.TimeUnit.SECOND, nothing}), missing],
       col18=[zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), zero(Arrow.Interval{Arrow.Meta.IntervalUnit.YEAR_MONTH, Int32}), missing],
       col19=[zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), zero(Arrow.Duration{Arrow.Meta.TimeUnit.SECOND}), missing],
+      col20=[zero(Arrow.Date{Arrow.Meta.DateUnit.MILLISECOND, Int64}), zero(Arrow.Date{Arrow.Meta.DateUnit.MILLISECOND, Int64}), zero(Arrow.Date{Arrow.Meta.DateUnit.MILLISECOND, Int64}), missing],
     ),
     NamedTuple(),
     (convert=false,),


### PR DESCRIPTION
Fixes #206. Looks like `DateTime` was just missing an `ArrowTypes.fromarrow` method. 