### PR TITLE
bump Project.toml from v1.4.1 to v1.5.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.4.1"
+version = "1.5.0"
 
 [deps]
 BitIntegers = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"


### PR DESCRIPTION
A minor bump seems reasonable since this release will include https://github.com/JuliaData/Arrow.jl/pull/160