### PR TITLE
Set ArrowTypes to version 1.1.0

### DIFF
--- a/src/ArrowTypes/Project.toml
+++ b/src/ArrowTypes/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrowTypes"
 uuid = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"


### PR DESCRIPTION
Needed for #212. Now that the packages will be treated as independent these changes need to be included in a release before the CI for Arrow.jl will pass on #212.