### PR TITLE
add metadata to `show` method

### DIFF
--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -93,6 +93,7 @@ include("eltypes.jl")
 include("table.jl")
 include("write.jl")
 include("append.jl")
+include("show.jl")
 
 const LZ4_FRAME_COMPRESSOR = LZ4FrameCompressor[]
 const ZSTD_COMPRESSOR = ZstdCompressor[]

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,0 +1,43 @@
+# 2-arg show: show schema and list # of metadata entries if non-zero
+function Base.show(io::IO, table::Table)
+    ncols = length(Tables.columnnames(table))
+    print(io, "$(typeof(table)) with $(Tables.rowcount(table)) rows, $(ncols) columns,")
+    meta = getmetadata(table)
+    if meta !== nothing && !isempty(meta)
+        print(io, " ", length(meta), " metadata entries,")
+    end
+    sch = Tables.schema(table)
+    if sch !== nothing
+        print(io, " and schema:\n")
+        show(IOContext(io, :print_schema_header => false), sch)
+    else
+        print(io, " and an unknown schema.")
+    end
+end
+
+# 3-arg show: show schema and show metadata entries adaptively according to `displaysize`
+function Base.show(io::IO, mime::MIME"text/plain", table::Table)
+    limit = get(io, :limit, false)::Bool
+    display_rows, display_cols = displaysize(io)
+    ncols = length(Tables.columnnames(table))
+    meta = getmetadata(table)
+    if meta !== nothing
+        display_rows -= 1 # decrement for metadata header line
+        display_rows -= min(length(meta), 2) # decrement so we can show at least 2 lines of metadata
+    end
+    print(io, "$(typeof(table)) with $(Tables.rowcount(table)) rows, $(ncols) columns, and ")
+    sch = Tables.schema(table)
+    if sch !== nothing
+        print(io, "schema:\n")
+        schema_context = IOContext(io, :print_schema_header => false, :displaysize => (max(display_rows, 3), display_cols))
+        schema_str = sprint(show, mime, sch; context=schema_context)
+        print(io, schema_str)
+        display_rows -= (count("\n", schema_str) + 1) # decrement for number of lines printed
+    else
+        print(io, "an unknown schema.")
+    end
+    if meta !== nothing
+        print(io, "\n\nwith metadata given by a ")
+        show(IOContext(io, :displaysize => (max(display_rows, 5), display_cols)), mime, meta)
+    end
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -7,12 +7,9 @@ function Base.show(io::IO, table::Table)
         print(io, " ", length(meta), " metadata entries,")
     end
     sch = Tables.schema(table)
-    if sch !== nothing
-        print(io, " and schema:\n")
-        show(IOContext(io, :print_schema_header => false), sch)
-    else
-        print(io, " and an unknown schema.")
-    end
+    print(io, " and schema:\n")
+    show(IOContext(io, :print_schema_header => false), sch)
+    return nothing
 end
 
 # 3-arg show: show schema and show metadata entries adaptively according to `displaysize`
@@ -27,17 +24,14 @@ function Base.show(io::IO, mime::MIME"text/plain", table::Table)
     end
     print(io, "$(typeof(table)) with $(Tables.rowcount(table)) rows, $(ncols) columns, and ")
     sch = Tables.schema(table)
-    if sch !== nothing
-        print(io, "schema:\n")
-        schema_context = IOContext(io, :print_schema_header => false, :displaysize => (max(display_rows, 3), display_cols))
-        schema_str = sprint(show, mime, sch; context=schema_context)
-        print(io, schema_str)
-        display_rows -= (count("\n", schema_str) + 1) # decrement for number of lines printed
-    else
-        print(io, "an unknown schema.")
-    end
+    print(io, "schema:\n")
+    schema_context = IOContext(io, :print_schema_header => false, :displaysize => (max(display_rows, 3), display_cols))
+    schema_str = sprint(show, mime, sch; context=schema_context)
+    print(io, schema_str)
+    display_rows -= (count("\n", schema_str) + 1) # decrement for number of lines printed
     if meta !== nothing
         print(io, "\n\nwith metadata given by a ")
         show(IOContext(io, :displaysize => (max(display_rows, 5), display_cols)), mime, meta)
     end
+    return nothing
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -207,23 +207,3 @@ function tobuffer(data; kwargs...)
     seekstart(io)
     return io
 end
-
-function Base.show(io::IO, table::Arrow.Table; max_cols = 20)
-    ncols = length(Tables.columnnames(table))
-    print(io, "$(typeof(table)) with $(Tables.rowcount(table)) rows, $(ncols) columns, and ")
-    sch = Tables.schema(table)
-    if sch !== nothing
-        print(io, "schema:\n")
-        show(IOContext(io, :print_schema_header => false), sch)
-    else
-        print(io, "an unknown schema.")
-    end
-    meta = getmetadata(table)
-    if meta !== nothing
-        print(io, "\n\nwith metadata:")
-        for kv in pairs(meta)
-            print(io, "\n  ")
-            show(io, kv)
-        end
-    end
-end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -207,3 +207,23 @@ function tobuffer(data; kwargs...)
     seekstart(io)
     return io
 end
+
+function Base.show(io::IO, table::Arrow.Table; max_cols = 20)
+    ncols = length(Tables.columnnames(table))
+    print(io, "$(typeof(table)) with $(Tables.rowcount(table)) rows, $(ncols) columns, and ")
+    sch = Tables.schema(table)
+    if sch !== nothing
+        print(io, "schema:\n")
+        show(IOContext(io, :print_schema_header => false), sch)
+    else
+        print(io, "an unknown schema.")
+    end
+    meta = getmetadata(table)
+    if meta !== nothing
+        print(io, "\n\nwith metadata:")
+        for kv in pairs(meta)
+            print(io, "\n  ")
+            show(io, kv)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -355,6 +355,24 @@ tbl = Arrow.Table(Arrow.tobuffer(t))
     @test eltype(tbl.col1) == VersionNumber
 end
 
+@testset "`show`" begin
+    table = (; a = 1:5, b = fill(1.0, 5))
+    arrow_table = Arrow.Table(Arrow.tobuffer(table))
+    str = sprint(show, arrow_table)
+    @test length(str) < 100
+    @test occursin("5 rows", str)
+    @test occursin("2 columns", str)
+    @test occursin("Int", str)
+    @test occursin("Float64", str)
+    @test !occursin("metadata", str)
+    Arrow.setmetadata!(arrow_table, Dict("test_meta" => "true", "a" => "2"))
+    str2 = sprint(show, arrow_table)
+    @test length(str2) > length(str)
+    @test length(str2) < 200
+    @test occursin("metadata", str2)
+    @test occursin("\"test_meta\" => \"true\"", str2)
+    @test occursin("\"a\" => \"2\"", str2)
+end
 end # @testset "misc"
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 using Test, Arrow, Tables, Dates, PooledArrays, TimeZones, UUIDs, CategoricalArrays, DataAPI
+using Random: randstring
 
 include(joinpath(dirname(pathof(Arrow)), "ArrowTypes/test/tests.jl"))
 include(joinpath(dirname(pathof(Arrow)), "../test/testtables.jl"))


### PR DESCRIPTION
Example:
```julia
julia> using Arrow, Random

julia> table = (; a = 1:5, b = fill(1.0, 5), c = rand(5), d = rand(5), e = rand(5), f = rand(5))
(a = 1:5, b = [1.0, 1.0, 1.0, 1.0, 1.0], c = [0.9115813936341635, 0.6017869550753863, 0.1209116726550763, 0.924149444926964, 0.7272289913844672], d = [0.45926036199324827, 0.10233921054413142, 0.9560755658854283, 0.05660762498131855, 0.28868047589910173], e = [0.9380512927621412, 0.2104221942290203, 0.6856440294685857, 0.2127248089022249, 0.008718444405296344], f = [0.6356638663678782, 0.9528447748053304, 0.6450695397849635, 0.7818312379347359, 0.8668961641219173])

julia> arrow_table = Arrow.Table(Arrow.tobuffer(table))
Arrow.Table with 5 rows, 6 columns, and schema:
 :a  Int64
 :b  Float64
 :c  Float64
 :d  Float64
 :e  Float64
 :f  Float64

julia> big_dict = Dict((randstring(rand(5:10)) => randstring(rand(1:3)) for _ = 1:100))
Dict{String, String} with 100 entries:
  "Bzk4Xi9e"   => "M"
  "SrgmyVr02R" => "o"
  "kFRlnQh6"   => "O"
  "6ccJjh"     => "h"
  "dOpt4wjlC"  => "tQ"
  "VfJlSKV9"   => "Xjt"
  "9iXDrx"     => "y9n"
  "bgX6sK8"    => "n"
  "EDsiHpCKoB" => "1"
  "X9W1cYb2Vh" => "d"
  ⋮            => ⋮

julia> Arrow.setmetadata!(arrow_table, big_dict)

julia> arrow_table
Arrow.Table with 5 rows, 6 columns, and schema:
 :a  Int64
 :b  Float64
 :c  Float64
 :d  Float64
 :e  Float64
 :f  Float64

with metadata given by a Dict{String, String} with 100 entries:
  "Bzk4Xi9e"   => "M"
  ⋮            => ⋮

julia> show(arrow_table)
Arrow.Table with 5 rows, 6 columns, 100 metadata entries, and schema:
 :a  Int64
 :b  Float64
 :c  Float64
 :d  Float64
 :e  Float64
 :f  Float64
```

The `show` method is borrowed from Tables.jl, so without metadata it is the same, but with metadata it also shows it. In the 2-argument show, it just lists the # of entries, and in the 3-argument show, it prints the dictionary with some care to fit within the `displaysize`. I.e. the amount of columns shown when printing the schema and the amount of metadata key/value pairs shown depends on the size of the REPL (or whatever the display frontend is, as long as it supports `displaysize`).