### PR TITLE
Support Julia 1.0 for ArrowTypes package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - Arrow.jl
           - ArrowTypes.jl
         version:
+          - '1.0'
           - '1.3'
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
@@ -25,6 +26,12 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+        exclude:
+          # Test Arrow.jl/ArrowTypes.jl on their oldest supported Julia versions
+          - pkg: Arrow.jl
+            version: '1.0'
+          - pkg: ArrowTypes.jl
+            version: '1.3'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,9 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-buildpkg@v1.2
+        with:
+          project: .github/pkgs/${{ matrix.pkg }}
       - uses: julia-actions/julia-runtest@v1
         with:
           project: .github/pkgs/${{ matrix.pkg }}

--- a/src/ArrowTypes/Project.toml
+++ b/src/ArrowTypes/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrowTypes"
 uuid = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"

--- a/src/ArrowTypes/Project.toml
+++ b/src/ArrowTypes/Project.toml
@@ -7,7 +7,7 @@ version = "1.1.0"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-julia = "1.3"
+julia = "1.0"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"


### PR DESCRIPTION
Allows for packages to depend on ArrowTypes.jl and still include support for the Julia 1.0 LTS.