### PR TITLE
use `_id` in warn logging

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -54,7 +54,7 @@ function juliaeltype(f::Meta.Field, meta::Dict{String, String}, convert::Bool)
         if JT !== nothing
             return f.nullable ? Union{JT, Missing} : JT
         else
-            @warn "unsupported ARROW:extension:name type: \"$typename\", arrow type = $TT" maxlog=1
+            @warn "unsupported ARROW:extension:name type: \"$typename\", arrow type = $TT" maxlog=1 _id=hash((:juliaeltype, typename, TT))
         end
     end
     return something(TTT, T)
@@ -262,7 +262,7 @@ finaljuliatype(::Type{Timestamp{U, TZ}}) where {U, TZ} = ZonedDateTime
 finaljuliatype(::Type{Timestamp{U, nothing}}) where {U} = DateTime
 
 @noinline warntimestamp(U, T) =
-    @warn "automatically converting Arrow.Timestamp with precision = $U to `$T` which only supports millisecond precision; conversion may be lossy; to avoid converting, pass `Arrow.Table(source; convert=false)" maxlog=1
+    @warn "automatically converting Arrow.Timestamp with precision = $U to `$T` which only supports millisecond precision; conversion may be lossy; to avoid converting, pass `Arrow.Table(source; convert=false)" maxlog=1 _id=hash((:warntimestamp, U, T))
 
 function Base.convert(::Type{ZonedDateTime}, x::Timestamp{U, TZ}) where {U, TZ}
     (U === Meta.TimeUnit.MICROSECOND || U == Meta.TimeUnit.NANOSECOND) && warntimestamp(U, ZonedDateTime)


### PR DESCRIPTION
Fixes the issue from https://github.com/JuliaData/Arrow.jl/pull/224#issuecomment-876772468:
```julia
julia> function f(x)
           @warn "Hello $x" x  maxlog=1 _id=hash((:f, x))
           return nothing
       end
f (generic function with 1 method)

julia> f(1)
┌ Warning: Hello 1
│   x = 1
└ @ Main REPL[24]:2

julia> f(1)

julia> f(1)

julia> f(2)
┌ Warning: Hello 2
│   x = 2
└ @ Main REPL[24]:2

julia> f(2)

julia>
```

It's really hard to add a test for this, because the Test logger doesn't respect `maxlog`.