### PR TITLE
custom struct getindex should deserialize based on the shape of the actual ArrowType, not the target JuliaType

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/src/arraytypes/struct.jl
+++ b/src/arraytypes/struct.jl
@@ -33,20 +33,20 @@ isnamedtuple(T) = false
 istuple(::Type{<:Tuple}) = true
 istuple(T) = false
 
-@propagate_inbounds function Base.getindex(s::Struct{T}, i::Integer) where {T}
+@propagate_inbounds function Base.getindex(s::Struct{T,S}, i::Integer) where {T,S}
     @boundscheck checkbounds(s, i)
     NT = Base.nonmissingtype(T)
     if isnamedtuple(NT) || istuple(NT)
         if NT !== T
-            return s.validity[i] ? NT(ntuple(j->s.data[j][i], fieldcount(NT))) : missing
+            return s.validity[i] ? NT(ntuple(j->s.data[j][i], fieldcount(S))) : missing
         else
-            return NT(ntuple(j->s.data[j][i], fieldcount(NT)))
+            return NT(ntuple(j->s.data[j][i], fieldcount(S)))
         end
     else
         if NT !== T
-            return s.validity[i] ? ArrowTypes.fromarrow(NT, (s.data[j][i] for j = 1:fieldcount(NT))...) : missing
+            return s.validity[i] ? ArrowTypes.fromarrow(NT, (s.data[j][i] for j = 1:fieldcount(S))...) : missing
         else
-            return ArrowTypes.fromarrow(NT, (s.data[j][i] for j = 1:fieldcount(NT))...)
+            return ArrowTypes.fromarrow(NT, (s.data[j][i] for j = 1:fieldcount(S))...)
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -390,6 +390,22 @@ end
 #194
 @test isempty(Arrow.Table(Arrow.tobuffer(Dict{Symbol, Vector}())))
 
+
+#229
+struct Foo229{x}
+    y::String
+    z::Int
+end
+Arrow.ArrowTypes.arrowname(::Type{<:Foo229}) = Symbol("JuliaLang.Foo229")
+Arrow.ArrowTypes.ArrowType(::Type{Foo229{x}}) where {x} = Tuple{String,String,Int}
+Arrow.ArrowTypes.toarrow(row::Foo229{x}) where {x} = (String(x), row.y, row.z)
+Arrow.ArrowTypes.JuliaType(::Val{Symbol("JuliaLang.Foo229")}, ::Any) = Foo229
+Arrow.ArrowTypes.fromarrow(::Type{<:Foo229}, x, y, z) = Foo229{Symbol(x)}(y, z)
+cols = (k1=[Foo229{:a}("a", 1), Foo229{:b}("b", 2)], k2=[Foo229{:c}("c", 3), Foo229{:d}("d", 4)])
+tbl = Arrow.Table(Arrow.tobuffer(cols))
+@test tbl.k1 == cols.k1
+@test tbl.k2 == cols.k2
+
 end # @testset "misc"
 
 end


### PR DESCRIPTION
This seems like it should be the case, and that `fromarrow` should be responsible for handling any fieldcount discrepancies, but I'm just messing about right now so could be missing something.

This arises in a case where the ArrowType has a different number of fields than the corresponding JuliaType 