### PR TITLE
remove global metadata cache, refactor custom_metadata API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Arrow"
 uuid = "69666777-d1a9-59fb-9406-91d4454c9d45"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.6.2"
+version = "2.0.0"
 
 [deps]
 ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -159,9 +159,13 @@ This stuff can definitely make your eyes glaze over if you stare at it long enou
 
 In addition to `Arrow.Table`, the Arrow.jl package also provides `Arrow.Stream` for processing arrow data. While `Arrow.Table` will iterate all record batches in an arrow file/stream, concatenating columns, `Arrow.Stream` provides a way to *iterate* through record batches, one at a time. Each iteration yields an `Arrow.Table` instance, with columns/data for a single record batch. This allows, if so desired, "batch processing" of arrow data, one record batch at a time, instead of creating a single long table via `Arrow.Table`.
 
-### Table and column metadata
+### Custom application metadata
 
-The arrow format allows attaching arbitrary metadata in the form of a `Dict{String, String}` to tables and individual columns. The Arrow.jl package supports retrieving serialized metadata by calling `Arrow.getmetadata(table)` or `Arrow.getmetadata(column)`.
+The Arrow format allows data producers to [attach custom metadata](https://arrow.apache.org/docs/format/Columnar.html#custom-application-metadata) to various Arrow objects.
+
+Arrow.jl provides a convenient accessor for this metadata via [`Arrow.getmetadata`](@ref). `Arrow.getmetadata(t::Arrow.Table)` will return an immutable `AbstractDict{String,String}` that represents the [`custom_metadata` of the table's associated `Schema`](https://github.com/apache/arrow/blob/85d8175ea24b4dd99f108a673e9b63996d4f88cc/format/Schema.fbs#L515) (or `nothing` if no such metadata exists), while `Arrow.getmetadata(c::Arrow.ArrowVector)` will return a similar representation of [the column's associated `Field` `custom_metadata`](https://github.com/apache/arrow/blob/85d8175ea24b4dd99f108a673e9b63996d4f88cc/format/Schema.fbs#L480) (or `nothing` if no such metadata exists).
+
+To attach custom schema/column metadata to Arrow tables at serialization time, see the `metadata` and `colmetadata` keyword arguments to [`Arrow.write`](@ref).
 
 ## Writing arrow data
 

--- a/src/Arrow.jl
+++ b/src/Arrow.jl
@@ -41,6 +41,7 @@ See docs for official Arrow.jl API with the [User Manual](@ref) and reference do
 """
 module Arrow
 
+using Base.Iterators
 using Mmap
 import Dates
 using DataAPI, Tables, SentinelArrays, PooledArrays, CodecLz4, CodecZstd, TimeZones, BitIntegers
@@ -106,7 +107,6 @@ function __init__()
         CodecLz4.TranscodingStreams.initialize(lz4)
         push!(LZ4_FRAME_COMPRESSOR, lz4)
     end
-    OBJ_METADATA_LOCK[] = ReentrantLock()
     return
 end
 

--- a/src/ArrowTypes/Project.toml
+++ b/src/ArrowTypes/Project.toml
@@ -1,7 +1,7 @@
 name = "ArrowTypes"
 uuid = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 authors = ["quinnj <quinn.jacobd@gmail.com>"]
-version = "1.2.1"
+version = "1.2.2"
 
 
 [deps]

--- a/src/ArrowTypes/src/ArrowTypes.jl
+++ b/src/ArrowTypes/src/ArrowTypes.jl
@@ -366,13 +366,6 @@ const JULIA_TO_ARROW_TYPE_MAPPING = Dict{Type, Tuple{String, Type}}()
 
 istyperegistered(::Type{T}) where {T} = haskey(JULIA_TO_ARROW_TYPE_MAPPING, T)
 
-function getarrowtype!(meta, ::Type{T}) where {T}
-    arrowname, arrowtype = JULIA_TO_ARROW_TYPE_MAPPING[T]
-    meta["ARROW:extension:name"] = arrowname
-    meta["ARROW:extension:metadata"] = ""
-    return arrowtype
-end
-
 const ARROW_TO_JULIA_TYPE_MAPPING = Dict{String, Tuple{Type, Type}}()
 
 function extensiontype(f, meta)

--- a/src/arraytypes/bool.jl
+++ b/src/arraytypes/bool.jl
@@ -25,7 +25,7 @@ struct BoolVector{T} <: ArrowVector{T}
     pos::Int
     validity::ValidityBitmap
     ℓ::Int64
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String, String}}
 end
 
 Base.size(p::BoolVector) = (p.ℓ,)

--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -35,7 +35,7 @@ mutable struct DictEncoding{T, S, A} <: ArrowVector{T}
     id::Int64
     data::A
     isOrdered::Bool
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String, String}}
 end
 
 indextype(::Type{DictEncoding{T, S, A}}) where {T, S, A} = S
@@ -91,7 +91,7 @@ struct DictEncoded{T, S, A} <: ArrowVector{T}
     validity::ValidityBitmap
     indices::Vector{S}
     encoding::DictEncoding{T, S, A}
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String, String}}
 end
 
 DictEncoded(b::Vector{UInt8}, v::ValidityBitmap, inds::Vector{S}, encoding::DictEncoding{T, S, A}, meta) where {S, T, A} =

--- a/src/arraytypes/dictencoding.jl
+++ b/src/arraytypes/dictencoding.jl
@@ -229,7 +229,7 @@ function arrowvector(::DictEncodedKind, x, i, nl, fi, de, ded, meta; dictencode:
         end
     end
     if meta !== nothing && getmetadata(encoding) !== nothing
-        merge!(meta, getmetadata(encoding))
+        meta = toidict(merge!(Dict(meta), Dict(getmetadata(encoding))))
     elseif getmetadata(encoding) !== nothing
         meta = getmetadata(encoding)
     end

--- a/src/arraytypes/fixedsizelist.jl
+++ b/src/arraytypes/fixedsizelist.jl
@@ -24,7 +24,7 @@ struct FixedSizeList{T, A <: AbstractVector} <: ArrowVector{T}
     validity::ValidityBitmap
     data::A
     ℓ::Int
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String,String}}
 end
 
 Base.size(l::FixedSizeList) = (l.ℓ,)

--- a/src/arraytypes/list.jl
+++ b/src/arraytypes/list.jl
@@ -39,7 +39,7 @@ struct List{T, O, A} <: ArrowVector{T}
     offsets::Offsets{O}
     data::A
     ℓ::Int
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String,String}}
 end
 
 Base.size(l::List) = (l.ℓ,)

--- a/src/arraytypes/map.jl
+++ b/src/arraytypes/map.jl
@@ -24,7 +24,7 @@ struct Map{T, O, A} <: ArrowVector{T}
     offsets::Offsets{O}
     data::A
     ℓ::Int
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String,String}}
 end
 
 Base.size(l::Map) = (l.ℓ,)

--- a/src/arraytypes/primitive.jl
+++ b/src/arraytypes/primitive.jl
@@ -24,7 +24,7 @@ struct Primitive{T, A} <: ArrowVector{T}
     validity::ValidityBitmap
     data::A
     ℓ::Int64
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String,String}}
 end
 
 Primitive(::Type{T}, b::Vector{UInt8}, v::ValidityBitmap, data::A, l, meta) where {T, A} =

--- a/src/arraytypes/struct.jl
+++ b/src/arraytypes/struct.jl
@@ -23,7 +23,7 @@ struct Struct{T, S} <: ArrowVector{T}
     validity::ValidityBitmap
     data::S # Tuple of ArrowVector
     ℓ::Int
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String,String}}
 end
 
 Base.size(s::Struct) = (s.ℓ,)

--- a/src/arraytypes/unions.jl
+++ b/src/arraytypes/unions.jl
@@ -63,7 +63,7 @@ struct DenseUnion{T, U, S} <: ArrowVector{T}
     typeIds::Vector{UInt8}
     offsets::Vector{Int32}
     data::S # Tuple of ArrowVector
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String,String}}
 end
 
 Base.size(s::DenseUnion) = size(s.typeIds)
@@ -185,7 +185,7 @@ struct SparseUnion{T, U, S} <: ArrowVector{T}
     arrow::Vector{UInt8} # need to hold a reference to arrow memory blob
     typeIds::Vector{UInt8}
     data::S # Tuple of ArrowVector
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing, Base.ImmutableDict{String,String}}
 end
 
 Base.size(s::SparseUnion) = size(s.typeIds)

--- a/src/eltypes.jl
+++ b/src/eltypes.jl
@@ -39,7 +39,7 @@ function juliaeltype(f::Meta.Field, ::Nothing, convert::Bool)
     return convert ? finaljuliatype(T) : T
 end
 
-function juliaeltype(f::Meta.Field, meta::Dict{String, String}, convert::Bool)
+function juliaeltype(f::Meta.Field, meta::AbstractDict{String, String}, convert::Bool)
     TT = juliaeltype(f, convert)
     !convert && return TT
     T = finaljuliatype(TT)

--- a/src/table.jl
+++ b/src/table.jl
@@ -182,19 +182,37 @@ struct Table <: Tables.AbstractColumns
     columns::Vector{AbstractVector}
     lookup::Dict{Symbol, AbstractVector}
     schema::Ref{Meta.Schema}
-    metadata::Ref{Dict{String, String}}
+    metadata::Ref{Union{Nothing,Base.ImmutableDict{String,String}}}
 end
 
-Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Dict{String, String}}())
-Table(names, types, columns, lookup, schema) = Table(names, types, columns, lookup, schema, Ref{Dict{String, String}}())
+Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Union{Nothing,Base.ImmutableDict{String,String}}}(nothing))
+
+function Table(names, types, columns, lookup, schema)
+    metadata = isassigned(schema) ? Ref(buildmetadata(schema[])) : Ref{Union{Nothing,Base.ImmutableDict{String,String}}}(nothing)
+    return Table(names, types, columns, lookup, schema, metadata)
+end
 
 names(t::Table) = getfield(t, :names)
 types(t::Table) = getfield(t, :types)
 columns(t::Table) = getfield(t, :columns)
 lookup(t::Table) = getfield(t, :lookup)
 schema(t::Table) = getfield(t, :schema)
-getmetadata(t::Table) = isdefined(getfield(t, :metadata), :x) ? getfield(t, :metadata)[] : nothing
-setmetadata!(t::Table, m::Dict{String, String}) = (setindex!(getfield(t, :metadata), m); nothing)
+
+"""
+    Arrow.getmetadata(x)
+
+If `x isa Arrow.Table` return a `Base.ImmutableDict{String,String}` representation of `x`'s
+`Schema` `custom_metadata`, or `nothing` if no such metadata exists.
+
+If `x isa Arrow.ArrowVector`, return a `Base.ImmutableDict{String,String}` representation of `x`'s
+`Field` `custom_metadata`, or `nothing` if no such metadata exists.
+
+Otherwise, return `nothing`.
+
+See [the official Arrow documentation for more details on custom application metadata](https://arrow.apache.org/docs/format/Columnar.html#custom-application-metadata).
+"""
+getmetadata(t::Table) = getfield(t, :metadata)[]
+getmetadata(::Any) = nothing
 
 Tables.istable(::Table) = true
 Tables.columnaccess(::Table) = true
@@ -306,10 +324,7 @@ function Table(bytes::Vector{UInt8}, off::Integer=1, tlen::Union{Integer, Nothin
         lu[nm] = col
         push!(ty, eltype(col))
     end
-    meta = sch !== nothing ? sch.custom_metadata : nothing
-    if meta !== nothing
-        getfield(t, :metadata)[] = buildmetadata(meta)
-    end
+    getfield(t, :metadata)[] = buildmetadata(sch)
     return t
 end
 
@@ -366,10 +381,10 @@ struct VectorIterator
     convert::Bool
 end
 
-buildmetadata(f::Meta.Field) = buildmetadata(f.custom_metadata)
-buildmetadata(meta) = Dict(String(kv.key) => String(kv.value) for kv in meta)
+buildmetadata(f::Union{Meta.Field,Meta.Schema}) = buildmetadata(f.custom_metadata)
+buildmetadata(meta) = toidict(String(kv.key) => String(kv.value) for kv in meta)
 buildmetadata(::Nothing) = nothing
-buildmetadata(x::Dict{String, String}) = x
+buildmetadata(x::AbstractDict) = x
 
 function Base.iterate(x::VectorIterator, (columnidx, nodeidx, bufferidx)=(Int64(1), Int64(1), Int64(1)))
     columnidx > length(x.schema.fields) && return nothing

--- a/src/table.jl
+++ b/src/table.jl
@@ -188,8 +188,8 @@ end
 Table() = Table(Symbol[], Type[], AbstractVector[], Dict{Symbol, AbstractVector}(), Ref{Meta.Schema}(), Ref{Union{Nothing,Base.ImmutableDict{String,String}}}(nothing))
 
 function Table(names, types, columns, lookup, schema)
-    metadata = isassigned(schema) ? Ref(buildmetadata(schema[])) : Ref{Union{Nothing,Base.ImmutableDict{String,String}}}(nothing)
-    return Table(names, types, columns, lookup, schema, metadata)
+    m = isassigned(schema) ? buildmetadata(schema[]) : nothing
+    return Table(names, types, columns, lookup, schema, Ref{Union{Nothing,Base.ImmutableDict{String,String}}}(m))
 end
 
 names(t::Table) = getfield(t, :names)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,10 +210,4 @@ end
 
 toidict(x::Base.ImmutableDict) = x
 
-function toidict(pairs)
-    dict = Base.ImmutableDict(first(pairs))
-    for pair in Iterators.drop(pairs, 1)
-        dict = Base.ImmutableDict(dict, pair)
-    end
-    return dict
-end
+toiddict(pairs) = foldl(Base.ImmutableDict, pairs)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,4 +210,11 @@ end
 
 toidict(x::Base.ImmutableDict) = x
 
-toidict(pairs) = foldl(Base.ImmutableDict, pairs)
+# ref https://github.com/JuliaData/Arrow.jl/pull/238#issuecomment-919415809
+function toidict(pairs)
+    dict = Base.ImmutableDict(first(pairs))
+    for pair in Iterators.drop(pairs, 1)
+        dict = Base.ImmutableDict(dict, pair)
+    end
+    return dict
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -208,6 +208,8 @@ function tobuffer(data; kwargs...)
     return io
 end
 
+toidict(x::Base.ImmutableDict) = x
+
 function toidict(pairs)
     dict = Base.ImmutableDict(first(pairs))
     for pair in Iterators.drop(pairs, 1)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -207,3 +207,11 @@ function tobuffer(data; kwargs...)
     seekstart(io)
     return io
 end
+
+function toidict(pairs)
+    dict = Base.ImmutableDict(first(pairs))
+    for pair in Iterators.drop(pairs, 1)
+        dict = Base.ImmutableDict(dict, pair)
+    end
+    return dict
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,4 +210,4 @@ end
 
 toidict(x::Base.ImmutableDict) = x
 
-toiddict(pairs) = foldl(Base.ImmutableDict, pairs)
+toidict(pairs) = foldl(Base.ImmutableDict, pairs)

--- a/src/write.jl
+++ b/src/write.jl
@@ -219,7 +219,7 @@ function toarrowtable(cols, dictencodings, largelists, compress, denseunions, di
     end
     minlen, maxlen = isempty(newcols) ? (0, 0) : extrema(length, newcols)
     minlen == maxlen || throw(ArgumentError("columns with unequal lengths detected: $minlen < $maxlen"))
-    meta = isnothing(meta) ? nothing : toidict(String(k) => String(v) for (k, v) in meta)
+    meta = _normalizemeta(meta)
     return ToArrowTable(Tables.Schema(sch.names, newtypes), newcols, meta, dictencodingdeltas)
 end
 

--- a/src/write.jl
+++ b/src/write.jl
@@ -14,39 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-const OBJ_METADATA_LOCK = Ref{ReentrantLock}()
-const OBJ_METADATA = IdDict{Any, Dict{String, String}}()
-
-"""
-    Arrow.setmetadata!(x, metadata::Dict{String, String})
-
-Set the metadata for any object, provided as a `Dict{String, String}`.
-Metadata attached to a table or column will be serialized when written
-as a stream or file.
-"""
-function setmetadata!(x, meta::Dict{String, String})
-    lock(OBJ_METADATA_LOCK[]) do
-        OBJ_METADATA[x] = meta
-    end
-    return
-end
-
-"""
-    Arrow.getmetadata(x) => Dict{String, String}
-
-Retrieve any metadata (as a `Dict{String, String}`) attached to `x`.
-
-Metadata may be attached to any object via [`Arrow.setmetadata!`](@ref),
-or deserialized via the arrow format directly (the format allows attaching metadata
-to table, column, and other objects).
-
-Note that this function's return value directly aliases `x`'s attached metadata
-(i.e. is not a copy of the underlying storage). Any method author that overloads
-this function should preserve this behavior so that downstream callers can rely
-on this behavior in generic code.
-"""
-getmetadata(x, default=nothing) = lock(() -> get(OBJ_METADATA, x, default), OBJ_METADATA_LOCK[])
-
 const DEFAULT_MAX_DEPTH = 6
 
 """
@@ -70,6 +37,7 @@ By default, `Arrow.write` will use multiple threads to write multiple
 record batches simultaneously (e.g. if julia is started with `julia -t 8` or the `JULIA_NUM_THREADS` environment variable is set).
 
 Supported keyword arguments to `Arrow.write` include:
+  * `colmetadata=nothing`: TODO
   * `compress`: possible values include `:lz4`, `:zstd`, or your own initialized `LZ4FrameCompressor` or `ZstdCompressor` objects; will cause all buffers in each record batch to use the respective compression encoding
   * `alignment::Int=8`: specify the number of bytes to align buffers to when written in messages; strongly recommended to only use alignment values of 8 or 64 for modern memory cache line optimization
   * `dictencode::Bool=false`: whether all columns should use dictionary encoding when being written; to dict encode specific columns, wrap the column/array in `Arrow.DictEncode(col)`
@@ -77,6 +45,7 @@ Supported keyword arguments to `Arrow.write` include:
   * `denseunions::Bool=true`: whether Julia `Vector{<:Union}` arrays should be written using the dense union layout; passing `false` will result in the sparse union layout
   * `largelists::Bool=false`: causes list column types to be written with Int64 offset arrays; mainly for testing purposes; by default, Int64 offsets will be used only if needed
   * `maxdepth::Int=$DEFAULT_MAX_DEPTH`: deepest allowed nested serialization level; this is provided by default to prevent accidental infinite recursion with mutually recursive data structures
+  * `metadata=Arrow.getmetadata(tbl)`: the metadata that should be written as the table's schema's `custom_metadata` field; must either be `nothing` or an iterable of `<:AbstractString` pairs.
   * `ntasks::Int`: number of concurrent threaded tasks to allow while writing input partitions out as arrow record batches; default is no limit; to disable multithreaded writing, pass `ntasks=1`
   * `file::Bool=false`: if a an `io` argument is being written to, passing `file=true` will cause the arrow file format to be written instead of just IPC streaming
 """
@@ -84,18 +53,18 @@ function write end
 
 write(io_or_file; kw...) = x -> write(io_or_file, x; kw...)
 
-function write(filename::String, tbl; largelists::Bool=false, compress::Union{Nothing, Symbol, LZ4FrameCompressor, ZstdCompressor}=nothing, denseunions::Bool=true, dictencode::Bool=false, dictencodenested::Bool=false, alignment::Int=8, maxdepth::Int=DEFAULT_MAX_DEPTH, ntasks=Inf, file::Bool=true)
+function write(filename::String, tbl; metadata=getmetadata(tbl), colmetadata=nothing, largelists::Bool=false, compress::Union{Nothing, Symbol, LZ4FrameCompressor, ZstdCompressor}=nothing, denseunions::Bool=true, dictencode::Bool=false, dictencodenested::Bool=false, alignment::Int=8, maxdepth::Int=DEFAULT_MAX_DEPTH, ntasks=Inf, file::Bool=true)
     open(filename, "w") do io
-        write(io, tbl, file, largelists, compress, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks)
+        write(io, tbl, file, largelists, compress, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks, metadata, colmetadata)
     end
     return filename
 end
 
-function write(io::IO, tbl; largelists::Bool=false, compress::Union{Nothing, Symbol, LZ4FrameCompressor, ZstdCompressor}=nothing, denseunions::Bool=true, dictencode::Bool=false, dictencodenested::Bool=false, alignment::Int=8, maxdepth::Int=DEFAULT_MAX_DEPTH, ntasks=Inf, file::Bool=false)
-    return write(io, tbl, file, largelists, compress, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks)
+function write(io::IO, tbl; metadata=getmetadata(tbl), colmetadata=nothing, largelists::Bool=false, compress::Union{Nothing, Symbol, LZ4FrameCompressor, ZstdCompressor}=nothing, denseunions::Bool=true, dictencode::Bool=false, dictencodenested::Bool=false, alignment::Int=8, maxdepth::Int=DEFAULT_MAX_DEPTH, ntasks=Inf, file::Bool=false)
+    return write(io, tbl, file, largelists, compress, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks, metadata, colmetadata)
 end
 
-function write(io, source, writetofile, largelists, compress, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks)
+function write(io, source, writetofile, largelists, compress, denseunions, dictencode, dictencodenested, alignment, maxdepth, ntasks, meta, colmeta)
     if ntasks < 1
         throw(ArgumentError("ntasks keyword argument must be > 0; pass `ntasks=1` to disable multithreaded writing"))
     end
@@ -137,7 +106,7 @@ function write(io, source, writetofile, largelists, compress, denseunions, dicte
         @debug 1 "processing table partition i = $i"
         tblcols = Tables.columns(tbl)
         if i == 1
-            cols = toarrowtable(tblcols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth)
+            cols = toarrowtable(tblcols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, meta, colmeta)
             sch[] = Tables.schema(cols)
             firstcols[] = cols
             put!(msgs, makeschemamsg(sch[], cols), i)
@@ -153,9 +122,9 @@ function write(io, source, writetofile, largelists, compress, denseunions, dicte
             put!(msgs, makerecordbatchmsg(sch[], cols, alignment), i, true)
         else
             if threaded
-                Threads.@spawn process_partition(tblcols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
+                Threads.@spawn process_partition(tblcols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror, meta, colmeta)
             else
-                @async process_partition(tblcols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
+                @async process_partition(tblcols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror, meta, colmeta)
             end
         end
     end
@@ -209,9 +178,9 @@ function write(io, source, writetofile, largelists, compress, denseunions, dicte
     return io
 end
 
-function process_partition(cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror)
+function process_partition(cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, msgs, alignment, i, sch, errorref, anyerror, meta, colmeta)
     try
-        cols = toarrowtable(cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth)
+        cols = toarrowtable(cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, meta, colmeta)
         if !isempty(cols.dictencodingdeltas)
             for de in cols.dictencodingdeltas
                 dictsch = Tables.Schema((:col,), (eltype(de.data),))
@@ -229,26 +198,28 @@ end
 struct ToArrowTable
     sch::Tables.Schema
     cols::Vector{Any}
-    metadata::Union{Nothing, Dict{String, String}}
+    metadata::Union{Nothing,Base.ImmutableDict{String,String}}
     dictencodingdeltas::Vector{DictEncoding}
 end
 
-function toarrowtable(cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth)
+function toarrowtable(cols, dictencodings, largelists, compress, denseunions, dictencode, dictencodenested, maxdepth, meta, colmeta)
     @debug 1 "converting input table to arrow formatted columns"
-    meta = getmetadata(cols)
     sch = Tables.schema(cols)
     types = collect(sch.types)
     N = length(types)
     newcols = Vector{Any}(undef, N)
     newtypes = Vector{Type}(undef, N)
     dictencodingdeltas = DictEncoding[]
+    colmeta = isnothing(colmeta) ? nothing : toidict(colmeta)
     Tables.eachcolumn(sch, cols) do col, i, nm
-        newcol = toarrowvector(col, i, dictencodings, dictencodingdeltas; compression=compress, largelists=largelists, denseunions=denseunions, dictencode=dictencode, dictencodenested=dictencodenested, maxdepth=maxdepth)
+        newcolmeta = isnothing(colmeta) ? getmetadata(col) : get(colmeta, nm, nothing)
+        newcol = toarrowvector(col, i, dictencodings, dictencodingdeltas, newcolmeta; compression=compress, largelists=largelists, denseunions=denseunions, dictencode=dictencode, dictencodenested=dictencodenested, maxdepth=maxdepth)
         newtypes[i] = eltype(newcol)
         newcols[i] = newcol
     end
     minlen, maxlen = isempty(newcols) ? (0, 0) : extrema(length, newcols)
     minlen == maxlen || throw(ArgumentError("columns with unequal lengths detected: $minlen < $maxlen"))
+    meta = isnothing(meta) ? nothing : toidict(String(k) => String(v) for (k, v) in meta)
     return ToArrowTable(Tables.Schema(sch.names, newtypes), newcols, meta, dictencodingdeltas)
 end
 


### PR DESCRIPTION
essentially implements the approach described here https://github.com/JuliaData/Arrow.jl/issues/90#issuecomment-914870675

~I haven't run tests fully locally yet so may still have some lingering bugs.~ They pass 😎 

I also haven't been super performance-conscious here so we should be careful to make sure regressions aren't being introduced. 

Since we're doing a major bump for this anyway, I wonder whether it's a good time to fully delete some of the lingering deprecations here.

closes #90, #211