### PR TITLE
Add ability to pass directory of inputs to Arrow.Table/Arrow.Stream

### DIFF
--- a/src/FlatBuffers/FlatBuffers.jl
+++ b/src/FlatBuffers/FlatBuffers.jl
@@ -16,6 +16,8 @@
 
 module FlatBuffers
 
+import Base: ==
+
 const UOffsetT = UInt32
 const SOffsetT = Int32
 const VOffsetT = UInt16

--- a/src/FlatBuffers/table.jl
+++ b/src/FlatBuffers/table.jl
@@ -32,6 +32,8 @@ const TableOrStruct = Union{Table, Struct}
 bytes(x::TableOrStruct) = getfield(x, :bytes)
 pos(x::TableOrStruct) = getfield(x, :pos)
 
+==(a::T, b::T) where {T <: TableOrStruct} = all(getproperty(a, p) == getproperty(b, p) for p in propertynames(a))
+
 (::Type{T})(b::Builder) where {T <: TableOrStruct} = T(b.bytes[b.head+1:end], get(b, b.head, Int32))
 
 getrootas(::Type{T}, bytes::Vector{UInt8}, offset) where {T <: Table} = init(T, bytes, offset + readbuffer(bytes, offset, UOffsetT))

--- a/src/table.jl
+++ b/src/table.jl
@@ -39,11 +39,13 @@ end
     Arrow.Stream(io::IO; convert::Bool=true)
     Arrow.Stream(file::String; convert::Bool=true)
     Arrow.Stream(bytes::Vector{UInt8}, pos=1, len=nothing; convert::Bool=true)
+    Arrow.Stream(inputs::Vector; convert::Bool=true)
 
 Start reading an arrow formatted table, from:
  * `io`, bytes will be read all at once via `read(io)`
  * `file`, bytes will be read via `Mmap.mmap(file)`
  * `bytes`, a byte vector directly, optionally allowing specifying the starting byte position `pos` and `len`
+ * A `Vector` of any of the above, in which each input should be an IPC or arrow file and must match schema
 
 Reads the initial schema message from the arrow stream/file, then returns an `Arrow.Stream` object
 which will iterate over record batch messages, producing an [`Arrow.Table`](@ref) on each iteration.
@@ -196,11 +198,13 @@ end
     Arrow.Table(io::IO; convert::Bool=true)
     Arrow.Table(file::String; convert::Bool=true)
     Arrow.Table(bytes::Vector{UInt8}, pos=1, len=nothing; convert::Bool=true)
+    Arrow.Table(inputs::Vector; convert::Bool=true)
 
 Read an arrow formatted table, from:
  * `io`, bytes will be read all at once via `read(io)`
  * `file`, bytes will be read via `Mmap.mmap(file)`
  * `bytes`, a byte vector directly, optionally allowing specifying the starting byte position `pos` and `len`
+ * A `Vector` of any of the above, in which each input should be an IPC or arrow file and must match schema
 
 Returns a `Arrow.Table` object that allows column access via `table.col1`, `table[:col1]`, or `table[1]`.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -437,6 +437,31 @@ end
 d = Arrow.FlatBuffers.getrootas(TestData, buf, 0);
 @test d.DataInt32 == UInt32[1,2,3]
 
+# test multiple inputs treated as one table
+t = (
+    col1=[1, 2, 3, 4, 5],
+    col2=[1.2, 2.3, 3.4, 4.5, 5.6],
+)
+tbl = Arrow.Table([Arrow.tobuffer(t), Arrow.tobuffer(t)])
+@test tbl.col1 == [1, 2, 3, 4, 5, 1, 2, 3, 4, 5]
+@test tbl.col2 == [1.2, 2.3, 3.4, 4.5, 5.6, 1.2, 2.3, 3.4, 4.5, 5.6]
+
+# schemas must match between multiple inputs
+t2 = (
+    col1=[1.2, 2.3, 3.4, 4.5, 5.6],
+)
+@test_throws ArgumentError Arrow.Table([Arrow.tobuffer(t), Arrow.tobuffer(t2)])
+
+# test multiple inputs treated as one table
+tbls = collect(Arrow.Stream([Arrow.tobuffer(t), Arrow.tobuffer(t)]))
+@test tbls[1].col1 == tbls[2].col1
+@test tbls[1].col2 == tbls[2].col2
+
+# schemas must match between multiple inputs
+t2 = (
+    col1=[1.2, 2.3, 3.4, 4.5, 5.6],
+)
+@test_throws ArgumentError collect(Arrow.Stream([Arrow.tobuffer(t), Arrow.tobuffer(t2)]))
 
 end # @testset "misc"
 


### PR DESCRIPTION
Implements #235. The proposed implementation here isn't too complicated;
it introduces a new `ArrowBlob` type that we'll convert any
`IO`/`String`/`Vector{UInt8}` input to, and the main
`Arrow.Table`/`Arrow.Stream` methods take a `Vector{ArrowBlob}` to
operate on. The schema of each input must match in order to be treated
as a single "table". "Must match" in this PR means `==(sch1, sch2)`,
which does include `custom_metadata` and dictionaries, which might not
be desireable, but I haven't quite had the chance to think through all
the way yet. Otherwise, I think the rest here is pretty straightfoward
and non-breaking.